### PR TITLE
Adding base styles to the new mobile ui 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ erl_crash.dump
 /config/*.secret.exs
 
 assets/src/config/
+
+# Webstorm
+.idea/
+
+bash /
+
+docker/

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1742,6 +1742,25 @@
         }
       }
     },
+    "@material-ui/icons": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.2.tgz",
+      "integrity": "sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "recompose": "0.28.0 - 0.30.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+          "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        }
+      }
+    },
     "@material-ui/system": {
       "version": "3.0.0-alpha.1",
       "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-3.0.0-alpha.1.tgz",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -44,15 +44,13 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -71,7 +69,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -268,7 +265,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -281,7 +277,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -347,8 +342,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.0",
@@ -365,7 +359,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -375,7 +368,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -386,15 +378,13 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -5739,8 +5729,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5761,14 +5750,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5783,20 +5770,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5913,8 +5897,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5926,7 +5909,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5941,7 +5923,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5949,14 +5930,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5975,7 +5954,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6056,8 +6034,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6069,7 +6046,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6155,8 +6131,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6192,7 +6167,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6212,7 +6186,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6256,14 +6229,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -12242,6 +12242,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typeface-roboto": {
+      "version": "0.0.54",
+      "resolved": "https://registry.npmjs.org/typeface-roboto/-/typeface-roboto-0.0.54.tgz",
+      "integrity": "sha512-sOFA1FXgP0gOgBYlS6irwq6hHYA370KE3dPlgYEJHL3PJd5X8gQE0RmL79ONif6fL5JZuGDj+rtOrFeOqz5IZQ=="
+    },
     "ua-parser-js": {
       "version": "0.7.18",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.5.0",
     "@fortawesome/react-fontawesome": "^0.1.3",
     "@material-ui/core": "^3.9.0",
+    "@material-ui/icons": "^3.0.2",
     "apollo-boost": "^0.1.20",
     "autoprefixer": "^9.3.1",
     "bootstrap": "^4.1.3",

--- a/assets/package.json
+++ b/assets/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^16.6.1",
     "react-ga": "^2.5.3",
     "react-router-dom": "^4.3.1",
+    "typeface-roboto": "0.0.54",
     "video.js": "^7.3.0",
     "yup": "^0.26.6"
   },

--- a/assets/src/components/Home.js
+++ b/assets/src/components/Home.js
@@ -1,7 +1,7 @@
-import React, {Component} from 'react'
+import React, { Component } from 'react'
 
-import {gql} from 'apollo-boost'
-import {Query} from 'react-apollo'
+import { gql } from 'apollo-boost'
+import { Query } from 'react-apollo'
 
 import Player from './Player'
 import Header from './Header'
@@ -21,10 +21,10 @@ export default class Home extends Component {
     }
   }
 
-  changeFeed = currentFeed => this.setState({currentFeed, autoplay: true})
+  changeFeed = currentFeed => this.setState({ currentFeed, autoplay: true })
 
   render() {
-    const {feedSlug} = this.props.match.params
+    const { feedSlug } = this.props.match.params
 
     return (
       <div className="home">
@@ -47,6 +47,7 @@ export default class Home extends Component {
                 control bar at the bottom lets you pause/play and shows how many
                 people are listening for whales with you.{' '}
               </p>
+              <p>this is a test</p>
               <p>
                 While you listen, you can also{' '}
                 <a href="http://www.orcasound.net/learn/" target="_blank">

--- a/assets/src/components/HomeV2.js
+++ b/assets/src/components/HomeV2.js
@@ -2,6 +2,7 @@ import React, { Component } from "react"
 import SiteMenu from "./SiteMenu"
 import { Button, Paper } from "@material-ui/core"
 import { createMuiTheme, MuiThemeProvider, withStyles } from '@material-ui/core/styles'
+import CssBaseline from "@material-ui/core/CssBaseline"
 import { blue, black } from '@material-ui/core/colors'
 import color from "@material-ui/core/colors/indigo";
 
@@ -36,13 +37,17 @@ export default class HomeV2 extends Component {
 
   render() {
     return (
-      <MuiThemeProvider theme={theme}>
-        <Paper
-          square
-        >
-          <SiteMenu />
-        </Paper>
-      </MuiThemeProvider>
+      <>
+        <CssBaseline>
+          <MuiThemeProvider theme={theme}>
+            <Paper
+              square
+            >
+              <SiteMenu />
+            </Paper>
+          </MuiThemeProvider>
+        </CssBaseline>
+      </>
     )
   }
 }

--- a/assets/src/components/HomeV2.js
+++ b/assets/src/components/HomeV2.js
@@ -1,19 +1,48 @@
 import React, { Component } from "react"
 import SiteMenu from "./SiteMenu"
 import { Button, Paper } from "@material-ui/core"
+import { createMuiTheme, MuiThemeProvider, withStyles } from '@material-ui/core/styles'
+import { blue, black } from '@material-ui/core/colors'
+import color from "@material-ui/core/colors/indigo";
+
+const theme = createMuiTheme(
+  {
+    /* config */
+    typography: {
+      useNextVariants: true,
+    },
+    palette: {
+      primary: {
+        main: '#2196f3',
+      },
+      secondary: {
+        main: '#009688',
+      }
+    },
+    spacing: {
+      unit: 10 // overriding default theme value of 8
+    }
+  }
+);
+
+console.log(theme);
 
 export default class HomeV2 extends Component {
   state = {}
 
   componentDidMount() {
-      document.title = `Orcasound`
+    document.title = `Orcasound`
   }
 
   render() {
     return (
-      <Paper square>
-        <SiteMenu />
-      </Paper>
+      <MuiThemeProvider theme={theme}>
+        <Paper
+          square
+        >
+          <SiteMenu />
+        </Paper>
+      </MuiThemeProvider>
     )
   }
 }

--- a/assets/src/components/HomeV2.js
+++ b/assets/src/components/HomeV2.js
@@ -8,7 +8,9 @@ import color from "@material-ui/core/colors/indigo";
 
 const theme = createMuiTheme(
   {
-    /* config */
+    /* change default theme options below */
+    /* gets merged into custom style objects */
+    /* using latest version of typography */
     typography: {
       useNextVariants: true,
     },
@@ -20,13 +22,8 @@ const theme = createMuiTheme(
         main: '#009688',
       }
     },
-    spacing: {
-      unit: 10 // overriding default theme value of 8
-    }
   }
 );
-
-console.log(theme);
 
 export default class HomeV2 extends Component {
   state = {}
@@ -42,6 +39,8 @@ export default class HomeV2 extends Component {
           <MuiThemeProvider theme={theme}>
             <Paper
               square
+              // This will get replaced when we add breakpoints
+              style={{ maxWidth: 599 }}
             >
               <SiteMenu />
             </Paper>

--- a/assets/src/components/SiteMenu.js
+++ b/assets/src/components/SiteMenu.js
@@ -1,46 +1,49 @@
 import React, { Component } from "react"
 import { Paper, Tabs, Tab, Button, Typography, Grid } from "@material-ui/core"
-//import { NotificationIcon } from "@material-ui/icons"
-//import { Notifications, ArrowDropDown } from "@material-ui/icons"
-
 import NotificationIcon from "@material-ui/icons/Notifications"
-import ArrowDropDown from "@material-ui/icons/ArrowDropDown"
+// import ArrowDropDown from "@material-ui/icons/ArrowDropDown"
 import { withStyles } from "@material-ui/core/styles"
 
 const styles = theme => ({
-  root: {
-  },
-  background: {
+  header: {
     background: "#000000",
     height: 80
   },
   h1: {
     color: "#ffffff",
-    fontFamily: 'Roboto-Medium',
     fontSize: 30,
     letterSpacing: 1.07,
-
     paddingLeft: 20,
-    paddingTop: 10,
+    paddingTop: 18,
   },
   button: {
-    fontFamily: 'Roboto-Regular',
     fontSize: 10,
     color: '#ffffff',
     opacity: .87,
-    textAlign: 'left'
+    textAlign: 'left',
+    height: 40
   },
   notificationIcon: {
-    fontSize: 16
+    fontSize: 16,
   },
-  // navTabs: {
-  //   display: 'flex',
-  //   justifyContent: 'space-evenly'
-  // },
   label: {
     fontSize: 14,
     textAlign: 'center',
   },
+  labelIcon: {
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  bodyHeader: {
+    marginLeft: 15,
+    marginRight: 15,
+    paddingTop: 18
+  },
+  bodyText: {
+    marginLeft: 15,
+    marginRight: 15,
+    marginTop: 15
+  }
 });
 
 export default withStyles(styles)(
@@ -59,34 +62,41 @@ export default withStyles(styles)(
     }
     mabyeAbout = () => {
       if (this.aboutTabSelected()) {
+        const { classes } = this.props;
         return (
-          <Paper gutterBottom>
+          <Paper>
             <Typography
               variant="h6"
-            >Welcome to OrcaSound!
-                </Typography>
+              className={classes.bodyHeader}
+            //style={{ paddingTop: 18 }}
+            >
+              Welcome to OrcaSound!
+            </Typography>
             <Typography
               component="p"
               paragraph={true}
+              className={classes.bodyText}
             >
               Learn what orcas sound like. Then listen live for them on underwater
               microphones (hydrophones).
-                </Typography>
+            </Typography>
             <Typography
               component="p"
               paragraph={true}
+              className={classes.bodyText}
             >
               Let us know when you hear them, or any sound you think is
               interesting! That will help researchers and stewards protect the
               orcas and their environment.
-                </Typography>
+            </Typography>
             <Typography
               component="p"
               paragraph={true}
+              className={classes.bodyText}
             >
               You can also get notified when our listeners or algorithms detect
               whales at any of our hydrophone locations.
-          </Typography>
+            </Typography>
           </Paper>
         )
       }
@@ -101,7 +111,7 @@ export default withStyles(styles)(
         >
           <Paper
             square
-            className={classes.background}
+            className={classes.header}
             elevation={1}
           >
             <Typography
@@ -132,7 +142,7 @@ export default withStyles(styles)(
             indicatorColor="primary"
             textColor="primary"
             onChange={this.handleChange}
-            centered
+          //centered
           >
             <Tab
               label="About"
@@ -143,11 +153,11 @@ export default withStyles(styles)(
             />
             <Tab
               label="Listen Live"
-              //disabled
+              disabled
               //icon={<ArrowDropDown />}
               fullWidth={true}
               classes={{
-                label: classes.label,
+                labelIcon: classes.labelIcon,
               }}
             >
             </Tab>
@@ -158,5 +168,3 @@ export default withStyles(styles)(
     }
   }
 )
-
-//export default SiteMenu

--- a/assets/src/components/SiteMenu.js
+++ b/assets/src/components/SiteMenu.js
@@ -1,68 +1,106 @@
 import React, { Component } from "react"
-import { Paper, Tabs, Tab, Button } from "@material-ui/core"
+import { Paper, Tabs, Tab, Button, Typography } from "@material-ui/core"
+import { withStyles } from "@material-ui/core/styles"
 
-class SiteMenu extends React.Component {
-  state = {
-    value: 0
-  }
+const styles = theme => ({
+  root: {
+  },
+  background: {
+    background: "#000000",
+    height: 80
+  },
+  h1: {
+    color: "#ffffff",
+    fontFamily: 'Roboto-Medium',
+    fontSize: 30,
+    letterSpacing: 1.07,
+    // marginRight: 203,
+    paddingLeft: 20,
+    paddingTop: 10,
+  },
+});
 
-  handleChange = (event, value) => {
-    console.log(value)
-    this.setState({ value })
-  }
+export default withStyles(styles)(
+  class SiteMenu extends React.Component {
+    state = {
+      value: 0
+    }
 
-  aboutTabSelected = () => {
-    return this.state.value == 0
-  }
-  mabyeAbout = () => {
-    if (this.aboutTabSelected()) {
+    handleChange = (event, value) => {
+      console.log(value)
+      this.setState({ value })
+    }
+
+    aboutTabSelected = () => {
+      return this.state.value == 0
+    }
+    mabyeAbout = () => {
+      if (this.aboutTabSelected()) {
+        return (
+          <Paper>
+            <p>Welcome to OrcaSound!</p>
+            <p>
+              Learn what orcas sound like. Then listen live for them on underwater
+              microphones (hydrophones).
+          </p>
+            <p>
+              Let us know when you hear them, or any sound you think is
+              interesting! That will help researchers and stewards protect the
+              orcas and their environment.
+          </p>
+            <p>
+              You can also get notified when our listeners or algorithms detect
+              whales at any of our hydrophone locations.
+          </p>
+          </Paper>
+        )
+      }
+    }
+
+    render() {
+      const { classes } = this.props;
+
       return (
-        <Paper>
-          <p>Welcome to OrcaSound!</p>
-          <p>
-            Learn what orcas sound like. Then listen live for them on underwater
-            microphones (hydrophones).
-          </p>
-          <p>
-            Let us know when you hear them, or any sound you think is
-            interesting! That will help researchers and stewards protect the
-            orcas and their environment.
-          </p>
-          <p>
-            You can also get notified when our listeners or algorithms detect
-            whales at any of our hydrophone locations.
-          </p>
+        <Paper
+          square
+        >
+          <Paper
+            square
+            className={classes.background}
+            elevation={1}
+          >
+            <Typography
+              component="h1"
+              className={classes.h1}
+              align="left"
+            >
+              Orcasound
+            </Typography>
+          </Paper>
+          <Button
+            color="primary"
+            variant="contained"
+            centered="true"
+            fullWidth={true}
+            className="sitemenu-notification-link"
+          >
+            Get notified when there's whale activity
+        </Button>
+          <Tabs
+            value={this.state.value}
+            indicatorColor="primary"
+            textColor="primary"
+            onChange={this.handleChange}
+            centered
+          >
+            <Tab label="About" />
+            <Tab label="Listen Live" disabled />
+          </Tabs>
+          {this.mabyeAbout()}
         </Paper>
       )
     }
   }
-  render() {
-    return (
-      <Paper square>
-        <Paper square>Orcasound</Paper>
-        <Button
-          color="primary"
-          variant="contained"
-          centered="true"
-          fullWidth={true}
-          className="sitemenu-notification-link"
-        >
-          Get notified when there's whale activity
-        </Button>
-        <Tabs
-          value={this.state.value}
-          indicatorColor="primary"
-          textColor="primary"
-          onChange={this.handleChange}
-          centered
-        >
-          <Tab label="About" />
-          <Tab label="Listen Live" disabled />
-        </Tabs>
-        {this.mabyeAbout()}
-      </Paper>
-    )
-  }
-}
+)
 
-export default SiteMenu
+//export default SiteMenu

--- a/assets/src/components/SiteMenu.js
+++ b/assets/src/components/SiteMenu.js
@@ -1,5 +1,10 @@
 import React, { Component } from "react"
-import { Paper, Tabs, Tab, Button, Typography } from "@material-ui/core"
+import { Paper, Tabs, Tab, Button, Typography, Grid } from "@material-ui/core"
+//import { NotificationIcon } from "@material-ui/icons"
+//import { Notifications, ArrowDropDown } from "@material-ui/icons"
+
+import NotificationIcon from "@material-ui/icons/Notifications"
+import ArrowDropDown from "@material-ui/icons/ArrowDropDown"
 import { withStyles } from "@material-ui/core/styles"
 
 const styles = theme => ({
@@ -14,9 +19,27 @@ const styles = theme => ({
     fontFamily: 'Roboto-Medium',
     fontSize: 30,
     letterSpacing: 1.07,
-    // marginRight: 203,
+
     paddingLeft: 20,
     paddingTop: 10,
+  },
+  button: {
+    fontFamily: 'Roboto-Regular',
+    fontSize: 10,
+    color: '#ffffff',
+    opacity: .87,
+    textAlign: 'left'
+  },
+  notificationIcon: {
+    fontSize: 16
+  },
+  // navTabs: {
+  //   display: 'flex',
+  //   justifyContent: 'space-evenly'
+  // },
+  label: {
+    fontSize: 14,
+    textAlign: 'center',
   },
 });
 
@@ -37,21 +60,33 @@ export default withStyles(styles)(
     mabyeAbout = () => {
       if (this.aboutTabSelected()) {
         return (
-          <Paper>
-            <p>Welcome to OrcaSound!</p>
-            <p>
+          <Paper gutterBottom>
+            <Typography
+              variant="h6"
+            >Welcome to OrcaSound!
+                </Typography>
+            <Typography
+              component="p"
+              paragraph={true}
+            >
               Learn what orcas sound like. Then listen live for them on underwater
               microphones (hydrophones).
-          </p>
-            <p>
+                </Typography>
+            <Typography
+              component="p"
+              paragraph={true}
+            >
               Let us know when you hear them, or any sound you think is
               interesting! That will help researchers and stewards protect the
               orcas and their environment.
-          </p>
-            <p>
+                </Typography>
+            <Typography
+              component="p"
+              paragraph={true}
+            >
               You can also get notified when our listeners or algorithms detect
               whales at any of our hydrophone locations.
-          </p>
+          </Typography>
           </Paper>
         )
       }
@@ -82,19 +117,40 @@ export default withStyles(styles)(
             variant="contained"
             centered="true"
             fullWidth={true}
-            className="sitemenu-notification-link"
+            className={classes.button}
+          // Do we need this className?  
+          // className="sitemenu-notification-link"
           >
             Get notified when there's whale activity
-        </Button>
+            <NotificationIcon
+              className={classes.notificationIcon}
+            />
+          </Button>
           <Tabs
             value={this.state.value}
+            variant="fullWidth"
             indicatorColor="primary"
             textColor="primary"
             onChange={this.handleChange}
             centered
           >
-            <Tab label="About" />
-            <Tab label="Listen Live" disabled />
+            <Tab
+              label="About"
+              fullWidth={true}
+              classes={{
+                label: classes.label
+              }}
+            />
+            <Tab
+              label="Listen Live"
+              //disabled
+              //icon={<ArrowDropDown />}
+              fullWidth={true}
+              classes={{
+                label: classes.label,
+              }}
+            >
+            </Tab>
           </Tabs>
           {this.mabyeAbout()}
         </Paper>


### PR DESCRIPTION
#### Adding the following npm dependencies
  - @material-ui/icons: version 3.0.2
  - typeface-roboto: version 0.0.54

#### Styles added to @material-ui components
- CssBaseline from @material-ui/core/CssBaseline
  - normalize css browser defaults
#### HomeV2.js
- createMuiTheme, createMuiThemeProvider from @material-ui/core/styles
  - Add theme colors from invision wireframes including:
    - primary:  #2196f3 
    - secondary:  #009688
#### SiteMenu.js
-  withStyles from @material-ui/core/styles
  -  add custom styles using JSS to align ui with invision wireframe prototype
#### Additional Notes
  - changed all text to typography components in order to take advantage of future benefits of using material-ui typography features - this should be more useful when we establish breakpoints and a desktop view.
  - Styled to maxWidth of 599px viewport so additional responsive styles will be necessary as we get a desktop design.  Happy to work on that next!
  -  inline code comments included where I felt they would help
