### PR TITLE
Add map.png to FeedPageV2

### DIFF
--- a/assets/src/components/FeedPageV2.js
+++ b/assets/src/components/FeedPageV2.js
@@ -22,11 +22,14 @@ const FeedName = styled(Typography)`
 `
 
 const FeedImageContainer = styled.div`
-  height: 50%;
-  background-image: url("https://s3.us-west-2.amazonaws.com/orcasite/rpi_orcasound_lab/map.png?response-content-disposition=inline&X-Amz-Security-Token=AgoGb3JpZ2luEKv%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLXdlc3QtMiKAAgKQKUJ8j2zMJMYfAg4f%2BAYvTVq%2FtftSDZjZSRhdQLNIlLgB7MQzCElnx4NGdiJ7eB3gnNZS7TnxmhY264TQTcdHWAPd6t5yFKd8va4P8ZrzhmsMUbUqQtBXidCjs1MycNGt4proco8Vn5Z6ysRRtbO%2FNIi10bslI9epLoUXwORKaG24XDx%2BdbGQ6S7816VHT4CwoTnzMAd31ogY2Op%2FwUT9hGzgFOAiRck53UNgd%2BAysXoCSBEFk44RLd%2FK1Dw4ULquq66XcddmU7HX24x4%2FAXVwYCvFtNcHPdzMRehqcy1fNYJD5%2FcMunZ7p2nm3%2BxwxS7BNI%2FpR4qnDFEZWJHfjYq%2BwMIgP%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw2NDgxODM3MjQ1NTUiDCq7B1%2FAPgq2l4RWbSrPA9NF0NKI1pFV5%2BTEvdPiazCrpep5s%2FN8lfPnvlcmG2Rvf25K9aZy9wvaLcUx9JPLkfazVWemOpMIi8sAp%2F4YDYPj31xSGzb0hxX9D88Sw2Vailnrs10%2BE91A5%2FaEbdjC%2Fp60vQXhtYZlWtzZ23nT1mzqOSBVUZ1B1zKkg3%2BGCzU0ipKRxW2djIFR8hbWTRfOQsHAzxEMirD3MTy56iTrEOEvAFEPCqomSyxNZJcY6mxHv1VLfFzty71hgyzehL94%2B3ofz1o5jezE3ldHtsmE2hgEuDdJAMr%2FRfVHoUATbuVn5xwuhRBNNYmh2hndR7wQZ7lVzvFUqYLglBi5ZVD0ZbF3SufGVpECgrSTWki4f6YzAWbKc17HzklgGZngZd5gX3UofJEmgG%2Fko4hY36yRFWaPqCaRJzJaICKvbAtuB36c%2B1blnnMCkprnICuvvvt3GM8DQk2W19i1K1FXjn3kY5C841GJ4XlHTDOqE3D87sOmgqVWM8mkrk1xhy8r8g8e5xXAgYVRLeXcO%2BEYWvDYTZJq5Koq2hdxPzaBPwB%2BNeedsyXotvazgjw7E2AVKQHf%2BesxL6fWe7KKpzf%2BpZZx1H5fYpDSpXqdoFH2%2BWjDvxMwgab25wU%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20190609T234408Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=ASIAZN2WCXIFQCB3WGZN%2F20190609%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Signature=f20d6faa1a550f0e3eb31e5621afe9a29cdb61ac0978dcd70cf0261bbed3caa2");
-  background-size: 375px;
-  height: 127px;
+  background-repeat: no-repeat;
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover; 
+  background-size: cover;
+  background-position: center;
   background-color: gray;
+  height: 127px;
 `
 
 const StyledIntroHTML = styled.div`
@@ -66,15 +69,16 @@ class FeedPageV2 extends Component {
           }
 
 
-          const { introHtml, thumbUrl } = feed
+          const { introHtml, thumbUrl, mapUrl } = feed
 
           return (
             <FeedPageContainer>
               <FeedName variant="h2">
                 {feed.name}
               </FeedName>
-              <FeedImageContainer>
-
+              <FeedImageContainer style={{
+                backgroundImage: `url(${mapUrl})`
+              }}>
               </FeedImageContainer>
               {this.props.children}
               <StyledIntroHTML>

--- a/assets/src/queries/feeds.js
+++ b/assets/src/queries/feeds.js
@@ -8,6 +8,7 @@ export const LIST_FEEDS = gql`
     slug
     nodeName
     thumbUrl
+    mapUrl
   }
 }
 `
@@ -22,6 +23,7 @@ query feed($slug: String!) {
     locationPoint
     introHtml
     thumbUrl
+    mapUrl
   }
 }
 `

--- a/lib/orcasite_web/graphql/types/feed.ex
+++ b/lib/orcasite_web/graphql/types/feed.ex
@@ -26,9 +26,15 @@ defmodule OrcasiteWeb.Types.Feed do
       end)
     end
 
+    field :map_url, :string do
+      resolve(fn %{node_name: node_name}, _, _ ->
+        {:ok, feed_s3_url(node_name, "map.png")}
+      end)
+    end
+
     field :intro_html, :string do
       resolve(fn %{node_name: node_name}, _, _ ->
-        with intro_url <- feed_s3_url(node_name, "intro.html")  |> to_charlist(),
+        with intro_url <- feed_s3_url(node_name, "intro.html") |> to_charlist(),
              {:ok, {{_, 200, _}, _, resp}} <- :httpc.request(intro_url) do
           intro_html =
             resp


### PR DESCRIPTION
- added s3 url to the Absinthe schema in lib/orcasite_web/graphql/types/feed.ex
- added mapUrl to the the feeds query in assets/src/queries/feeds.js
- added the mapUrl image to the FeedPageV2.js component and applied base styles
- used built in styles attribute to reference the prop.  Could there be a better/more efficient way?
- Will add additional sizes images for responsiveness during desktop design update/this is the mobile first image only
