### PR TITLE
Add google analytics events

### DIFF
--- a/assets/src/components/AudioExamples.js
+++ b/assets/src/components/AudioExamples.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { Typography, Box, Grid, Avatar } from "@material-ui/core"
 import wave from "../../static/wave-orca.png"
+import analyticsEvents from "../utils/analyticsEvents"
 
 const AudioExamples = props => {
   return (
@@ -74,7 +75,13 @@ const AudioExamples = props => {
             </Grid>
             <Grid item xs={12}>
               <Box ml={{ xs: 3, sm: 9, md: 12, lg: 20 }}>
-                <audio controls src={example.audio} />
+                <audio
+                  controls
+                  src={example.audio}
+                  onPlay={() =>
+                    analyticsEvents.about.sampleAudioPlayed(example.title)
+                  }
+                />
               </Box>
             </Grid>
           </Grid>

--- a/assets/src/components/DetectionDialog.js
+++ b/assets/src/components/DetectionDialog.js
@@ -14,6 +14,7 @@ import DialogContent from "@material-ui/core/DialogContent"
 import DialogTitle from "@material-ui/core/DialogTitle"
 
 import styled from "styled-components"
+import analyticsEvents from "../utils/analyticsEvents"
 
 const StyledActivityButton = styled(Button)`
   color: #ffffff;
@@ -41,6 +42,7 @@ export default class DetectionDialog extends Component {
   }
   handleClickOpen = () => {
     this.setState({ open: true })
+    analyticsEvents.detection.dialogOpened(this.props.feed.slug)
   }
 
   handleChange = e => this.setState({ description: e.target.value })
@@ -57,6 +59,7 @@ export default class DetectionDialog extends Component {
       submitted: false,
       description: ""
     })
+    analyticsEvents.detection.dialogClosed(this.props.feed.slug)
   }
 
   onDetect = submitDetection => {
@@ -80,6 +83,7 @@ export default class DetectionDialog extends Component {
           listenerCount
         }
       })
+      analyticsEvents.detection.submitted(this.props.feed.slug)
     }
   }
 

--- a/assets/src/components/FeedList.js
+++ b/assets/src/components/FeedList.js
@@ -17,6 +17,7 @@ import { ArrowDropDown, Person } from "@material-ui/icons"
 import { feedType } from "types/feedType"
 import { storeCurrentFeed, getCurrentFeed } from "utils/feedStorage"
 import { LIST_FEEDS } from "../queries/feeds"
+import ReactGA from 'react-ga'
 
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -64,6 +65,7 @@ const FeedList = React.forwardRef((props, ref) => {
   const classes = useStyles()
 
   const handleToggle = () => {
+    ReactGA.event({category: "Feed list", action: "Menu opened"})
     setOpen(prevOpen => !prevOpen)
   }
 

--- a/assets/src/components/FeedList.js
+++ b/assets/src/components/FeedList.js
@@ -17,7 +17,7 @@ import { ArrowDropDown, Person } from "@material-ui/icons"
 import { feedType } from "types/feedType"
 import { storeCurrentFeed, getCurrentFeed } from "utils/feedStorage"
 import { LIST_FEEDS } from "../queries/feeds"
-import ReactGA from 'react-ga'
+import analyticsEvents from "../utils/analyticsEvents"
 
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -65,8 +65,8 @@ const FeedList = React.forwardRef((props, ref) => {
   const classes = useStyles()
 
   const handleToggle = () => {
-    ReactGA.event({category: "Feed list", action: "Menu opened"})
     setOpen(prevOpen => !prevOpen)
+    analyticsEvents.nav.listenTabClicked()
   }
 
   const handleClose = event => {
@@ -135,6 +135,7 @@ const FeedList = React.forwardRef((props, ref) => {
                                   key={feed.name}
                                   component={Link}
                                   to={`/${feed.slug}`}
+                                  onClick={() => analyticsEvents.nav.feedSelected(feed.name) }
                                 >
                                   {feed.name}
                                 </MenuItem>

--- a/assets/src/components/GiveFeedback.js
+++ b/assets/src/components/GiveFeedback.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { AppBar, Button, Link, Grid, makeStyles } from "@material-ui/core"
+import ReactGA from 'react-ga'
 
 const useStyles = makeStyles(theme => ({
   appBar: {
@@ -63,6 +64,7 @@ const GiveFeedback = () => {
               rel="noopener"
               rel="noreferrer"
               className={classes.link}
+              onClick={() => ReactGA.event({category: "Give Feedback", action: "Button clicked"})}
             >
               Give Feedback
             </Link>

--- a/assets/src/components/GiveFeedback.js
+++ b/assets/src/components/GiveFeedback.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { AppBar, Button, Link, Grid, makeStyles } from "@material-ui/core"
-import ReactGA from 'react-ga'
+import analyticsEvents from "../utils/analyticsEvents"
 
 const useStyles = makeStyles(theme => ({
   appBar: {
@@ -64,7 +64,7 @@ const GiveFeedback = () => {
               rel="noopener"
               rel="noreferrer"
               className={classes.link}
-              onClick={() => ReactGA.event({category: "Give Feedback", action: "Button clicked"})}
+              onClick={analyticsEvents.form.feedbackButtonClicked}
             >
               Give Feedback
             </Link>

--- a/assets/src/components/Player.js
+++ b/assets/src/components/Player.js
@@ -9,6 +9,7 @@ import { feedType } from "../types/feedType"
 import { storeCurrentFeed, getCurrentFeed } from "../utils/feedStorage"
 
 import styled from "styled-components"
+import analyticsEvents from "../utils/analyticsEvents"
 
 const PlayerContainer = styled.div`
   .video-js {
@@ -165,8 +166,24 @@ class Player extends Component {
           >
             <StyledButtonContainer active={isPlaying}>
               <Fab color="secondary" onClick={playPause}>
-                {!isPlaying && <PlayArrow className="icon" fontSize="large" />}
-                {isPlaying && <Pause className="icon" fontSize="large" />}
+                {!isPlaying && (
+                  <PlayArrow
+                    className="icon"
+                    fontSize="large"
+                    onClick={() =>
+                      analyticsEvents.stream.started(currentFeed.slug)
+                    }
+                  />
+                )}
+                {isPlaying && (
+                  <Pause
+                    className="icon"
+                    fontSize="large"
+                    onClick={() =>
+                      analyticsEvents.stream.paused(currentFeed.slug)
+                    }
+                  />
+                )}
               </Fab>
 
               {isPlaying && (

--- a/assets/src/components/Root.js
+++ b/assets/src/components/Root.js
@@ -1,7 +1,9 @@
 import { hot } from "react-hot-loader/root"
 
 import React from "react"
-import { BrowserRouter, Switch, Route } from "react-router-dom"
+import { Router, Switch, Route } from "react-router-dom"
+import { createBrowserHistory } from 'history'
+import ReactGA from 'react-ga'
 
 import AdminRoute from "./AdminRoute"
 
@@ -10,9 +12,15 @@ import Admin from "./admin/Dashboard"
 import DynamicFeed from "./DynamicFeed"
 import Login from "./Login"
 
+const history = createBrowserHistory()
+history.listen((location, action) => {
+  ReactGA.set({ page: location.pathname });
+  ReactGA.pageview(location.pathname + location.search);
+});
+
 const Root = props => {
   return (
-    <BrowserRouter>
+    <Router history={history}>
       <Switch>
         <Route exact path="/" component={Home} />
         <Route
@@ -31,7 +39,7 @@ const Root = props => {
 
         <Route path="/:feedSlug" component={Home} />
       </Switch>
-    </BrowserRouter>
+    </Router>
   )
 }
 

--- a/assets/src/components/SiteMenu.js
+++ b/assets/src/components/SiteMenu.js
@@ -14,6 +14,7 @@ import {
 } from "@material-ui/core"
 import NotificationIcon from "@material-ui/icons/Notifications"
 import FeedList from "./FeedList"
+import ReactGA from 'react-ga'
 
 const useStyles = makeStyles(theme => ({
   button: {
@@ -114,6 +115,7 @@ const SiteMenu = () => {
           label="About"
           component={RouterLink}
           to="/"
+          onClick={() => ReactGA.event({category: "Site Menu", action: "About tab clicked"})}
         />
         <Tab value="listen" label="Listen Live" component={FeedList} />
       </Tabs>

--- a/assets/src/components/SiteMenu.js
+++ b/assets/src/components/SiteMenu.js
@@ -14,7 +14,7 @@ import {
 } from "@material-ui/core"
 import NotificationIcon from "@material-ui/icons/Notifications"
 import FeedList from "./FeedList"
-import ReactGA from 'react-ga'
+import analyticsEvents from "../utils/analyticsEvents"
 
 const useStyles = makeStyles(theme => ({
   button: {
@@ -67,6 +67,7 @@ const SiteMenu = () => {
               underline="none"
               variant="inherit"
               className={classes.link}
+              onClick={analyticsEvents.nav.logoClicked}
             >
               <Box ml={1} pt={3}>
                 Orcasound
@@ -92,6 +93,7 @@ const SiteMenu = () => {
               color="inherit"
               variant="inherit"
               className={classes.link}
+              onClick={analyticsEvents.form.notificationSignupClicked}
             >
               Get notified when there's whale activity
             </Link>
@@ -115,7 +117,7 @@ const SiteMenu = () => {
           label="About"
           component={RouterLink}
           to="/"
-          onClick={() => ReactGA.event({category: "Site Menu", action: "About tab clicked"})}
+          onClick={analyticsEvents.nav.aboutTabClicked}
         />
         <Tab value="listen" label="Listen Live" component={FeedList} />
       </Tabs>

--- a/assets/src/utils/analyticsEvents.js
+++ b/assets/src/utils/analyticsEvents.js
@@ -1,0 +1,76 @@
+import ReactGA from "react-ga"
+
+const about = {
+  sampleAudioPlayed: (exampleTitle) =>
+    ReactGA.event({
+      category: "About",
+      action: "Sample audio played",
+      label: exampleTitle,
+    }),
+}
+
+const detection = {
+  dialogOpened: (feedSlug) =>
+    ReactGA.event({
+      category: "Detection",
+      action: "Dialog opened",
+      label: feedSlug,
+    }),
+  dialogClosed: (feedSlug) =>
+    ReactGA.event({
+      category: "Detection",
+      action: "Dialog closed",
+      label: feedSlug,
+    }),
+  submitted: (feedSlug) =>
+    ReactGA.event({
+      category: "Detection",
+      action: "Detection submitted",
+      label: feedSlug,
+    }),
+}
+
+const stream = {
+  started: (feedSlug) =>
+    ReactGA.event({
+      category: "Stream",
+      action: "Player started",
+      label: feedSlug,
+    }),
+  paused: (feedSlug) =>
+    ReactGA.event({
+      category: "Stream",
+      action: "Player paused",
+      label: feedSlug,
+    }),
+}
+
+const nav = {
+  logoClicked: () =>
+    ReactGA.event({ category: "Navigation", action: "Home logo clicked" }),
+  aboutTabClicked: () =>
+    ReactGA.event({ category: "Navigation", action: "About tab clicked" }),
+  listenTabClicked: () =>
+    ReactGA.event({ category: "Navigation", action: "Listen tab clicked" }),
+  feedSelected: (feedName) =>
+    ReactGA.event({
+      category: "Nav",
+      action: "Feed selected",
+      label: feedName,
+    }),
+}
+
+const form = {
+  notificationSignupClicked: () =>
+    ReactGA.event({ category: "Form", action: "Notification signup clicked" }),
+  feedbackButtonClicked: () =>
+    ReactGA.event({ category: "Form", action: "Feedback button clicked" }),
+}
+
+export default {
+  about,
+  detection,
+  stream,
+  nav,
+  form,
+}


### PR DESCRIPTION
To test this out in a dev environment, you'll have to grab a google analytics token and add it to your env as `GOOGLE_ANALYTICS_ID`.

This is just a rough example, it doesn't have to be merged, just creating a PR for reference. We should maybe figure out a nice way to avoid having to import ReactGA all over the place and instead send up click handlers