### PR TITLE
Fix mixed https warning on homepage

### DIFF
--- a/assets/src/components/AudioExamples.js
+++ b/assets/src/components/AudioExamples.js
@@ -96,17 +96,17 @@ AudioExamples.defaultProps = {
     {
       title: "Orca Calls",
       audio:
-        "http://www.orcasound.net/data/product/SRKW/orcasite/call-examples.mp3"
+        "https://www.orcasound.net/data/product/SRKW/orcasite/call-examples.mp3"
     },
     {
       title: "Orca Clicks",
       audio:
-        "http://orcasound.net/data/product/SRKW/clicks/20190705-JK_varied_clicks-10sec.mp3"
+        "https://orcasound.net/data/product/SRKW/clicks/20190705-JK_varied_clicks-10sec.mp3"
     },
     {
       title: "Orca Whistles",
       audio:
-        "http://www.orcasound.net/data/product/SRKW/orcasite/whistle-examples.mp3"
+        "https://www.orcasound.net/data/product/SRKW/orcasite/whistle-examples.mp3"
     }
   ]
 }


### PR DESCRIPTION
This is how the warnings appear in the browser:
![Screenshot 2021-04-29 07 57 02](https://user-images.githubusercontent.com/9973/116596794-8c8a6780-a8c0-11eb-857b-88c7380b36fc.png)
![Screenshot 2021-04-29 07 57 17](https://user-images.githubusercontent.com/9973/116596810-901dee80-a8c0-11eb-86d0-d0653005628c.png)
