### PR TITLE
Add config for Heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,7 @@
         "heroku-postgresql:hobby-dev"
       ],
       "scripts": {
-        "postdeploy": "POOL_SIZE=2 mix ecto.migrate && mix run priv/repo/seeds.exs"
+        "postdeploy": "POOL_SIZE=2 mix ecto.migrate && mix run priv/repo/seeds.exs && export HOST_URL=orcasite-test-${HEROKU_APP_NAME}.herokuapp.com && export URLS='//${HOST_URL}'"
       }
     }
   }

--- a/app.json
+++ b/app.json
@@ -15,7 +15,7 @@
       "formation": {
         "web": {
           "quantity": 1,
-          "size": "free"
+          "size": "hobby"
         }
       },
       "addons": [

--- a/app.json
+++ b/app.json
@@ -1,0 +1,29 @@
+{
+  "name": "Orcasite",
+  "website": "https://live.orcasound.net/",
+  "repository": "https://github.com/orcasound/orcasite",
+  "environments": {
+    "review": {
+      "buildpacks": [
+        {
+          "url": "https://github.com/HashNuke/heroku-buildpack-elixir"
+        },
+        {
+          "url": "https://github.com/gjaldon/heroku-buildpack-phoenix-static"
+        }
+      ],
+      "formation": {
+        "web": {
+          "quantity": 1,
+          "size": "free"
+        }
+      },
+      "addons": [
+        "heroku-postgresql:hobby-dev"
+      ],
+      "scripts": {
+        "postdeploy": "POOL_SIZE=2 mix ecto.migrate && mix run priv/repo/seeds.exs"
+      }
+    }
+  }
+}

--- a/app.json
+++ b/app.json
@@ -22,7 +22,7 @@
         "heroku-postgresql:hobby-dev"
       ],
       "scripts": {
-        "postdeploy": "POOL_SIZE=2 mix ecto.migrate && mix run priv/repo/seeds.exs && export HOST_URL=orcasite-test-${HEROKU_APP_NAME}.herokuapp.com && export URLS='//${HOST_URL}'"
+        "postdeploy": "POOL_SIZE=2 mix ecto.migrate && mix run priv/repo/seeds.exs"
       }
     }
   }


### PR DESCRIPTION
This PR adds an [`app.json` file](https://devcenter.heroku.com/articles/app-json-schema) which is needed in order to get [Heroku review apps](https://devcenter.heroku.com/articles/github-integration-review-apps#configuration) working. Review apps will let us spin up temporary versions of the website for each PR, so that everyone can see/test the changes without having to load up the dev environment on their local machine.

This is just an initial experiment, so currently review apps won't be created automatically for each PR. Members of the Orcasound team on Heroku can spin up new review apps from the [Heroku dashboard](https://dashboard.heroku.com/teams/orcasound/apps).

A review app is a completely new app instance on Heroku, and as a result has all the features the staging and prod apps have. This includes separate environment variables and a new database (seeded with `mix run priv/repo/seeds.exs`). Review apps are set to be deleted if they aren't used for a few days.

There are also a few known issues that I didn't get a chance to address in this initial PR:

- Database migrations only run on the initial review app creation
  - Additional pushes to a PR will cause the review app to redeploy, but won't re-run migrations. The proper fix is to set up the [Heroku release phase](https://devcenter.heroku.com/articles/release-phase), but for now the review app can just be deleted and re-created.
- It's currently configured to use a `hobby` dyno ($7/month)
  - Because `free` dynos can't be created by Heroku team accounts
  - But it is pro-rated based on how long it stays up for so hopefully costs are manageable, especially if we can get rid of the current staging instance.
- Websocket support (and maybe other stuff) is broken
  - This is because the `HOST_URL` and `URLS` environment variables aren't being set correctly at the moment. Each review app is assigned a different URL, which is generated dynamically. Heroku does provide a way to access this information via the [injected environment variables](https://devcenter.heroku.com/articles/github-integration-review-apps#injected-environment-variables), but I choose not to modify `config/prod.exs` to be Heroku specific.
  - Why? Because there's a better solution, moving to the new way to load configuration in Elixir 1.11+ via `runtime.exs`. The [new method](https://hexdocs.pm/elixir/master/Config.html) allows env vars to be loaded dynamically at run time instead of compile time.