### PR TITLE
Add autoidle heroku addon to review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,9 +18,7 @@
           "size": "hobby"
         }
       },
-      "addons": [
-        "heroku-postgresql:hobby-dev"
-      ],
+      "addons": ["heroku-postgresql:hobby-dev", "autoidle:hobby"],
       "scripts": {
         "postdeploy": "POOL_SIZE=2 mix ecto.migrate && mix run priv/repo/seeds.exs"
       }


### PR DESCRIPTION
https://elements.heroku.com/addons/autoidle

This add-on should automatically idle apps so that they don't cost dyno time. Only caveat is that idled apps will error out on the first request, so you'll have to retry once the dyno starts up (usually after 5-10 seconds). Or this can be avoided by using the  `autoidleapp.com` domain instead of `herokuapp.com` (e.g. https://orcasite-pr-71.autoidleapp.com/ instead of https://orcasite-pr-71.herokuapp.com/), in which case the site will load slowly while the dynos spin up, but without erroring out.