### PR TITLE
Add migration to prune postgis spatial_ref_sys table

### DIFF
--- a/priv/repo/migrations/20211026044914_prune_postgis_spatial_ref_sys.exs
+++ b/priv/repo/migrations/20211026044914_prune_postgis_spatial_ref_sys.exs
@@ -1,0 +1,23 @@
+defmodule Orcasite.Repo.Migrations.PrunePostgisSpatialRefSys do
+  use Ecto.Migration
+
+  # Disable DDL transations because for some reason it causes the migration to
+  # hang if the query has an error (which would sometimes happen on Heroku)
+  @disable_ddl_transaction true
+
+  def change do
+    # Remove all the SRIDs we're not using. Currently only using 4326 (WGS84)
+    # This saves >5k rows, which is important because Heroku postgres hobby has
+    # a limit of 10k rows
+    # See https://github.com/rgeo/activerecord-postgis-adapter/issues/273
+    #
+    # This migration is irreversible (on purpose), but the default SRIDs can be
+    # restored by running the spatial_ref_sys.sql script that comes with postgis
+    #
+    # Using `query` instead of `execute` so that in case of a DB error, the
+    # migration fails silently. This makes the migration "optional". It's a bit
+    # weird but necessary because Heroku has problems with postgis permissions.
+    # See https://github.com/orcasound/orcasite/pull/74 for details
+    repo().query("DELETE FROM spatial_ref_sys WHERE srid NOT IN (4326);")
+  end
+end


### PR DESCRIPTION
By default postgis generates over 5000 rows of spatial/coordinate reference systems (CRS) and stores them in the `spatial_ref_sys` table. We only use one of those currently (SRID [4326](https://epsg.io/4326)). Heroku limits hobby postgres to 10k rows, and `spatial_ref_sys` uses up over half of them. This migration removes all the extra CRSs. They can easily be added back in later by running the `spatial_ref_sys.sql` script that comes with postgis, or one at a time (e.g. https://epsg.io/3857.sql). See https://github.com/rgeo/activerecord-postgis-adapter/issues/273 for more details