### PR TITLE
Switch phoenix heroku buildpack to gigalixir fork

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
           "url": "https://github.com/HashNuke/heroku-buildpack-elixir"
         },
         {
-          "url": "https://github.com/gjaldon/heroku-buildpack-phoenix-static"
+          "url": "https://github.com/gigalixir/gigalixir-buildpack-phoenix-static"
         }
       ],
       "formation": {


### PR DESCRIPTION
Resolves issue caused by heroku deprecation
https://devcenter.heroku.com/changelog-items/2598