### PR TITLE
Add first pass of confirmed detection email template

### DIFF
--- a/server/lib/orcasite/notifications/email.ex
+++ b/server/lib/orcasite/notifications/email.ex
@@ -65,7 +65,7 @@ defmodule Orcasite.Notifications.Email do
     """
     <mjml>
       <mj-body>
-        <mj-section padding="0" full-width background-color="#c4cdd3">
+        <mj-section padding="0" full-width="" background-color="#c4cdd3">
           <mj-column padding="0">
             <mj-image src="https://orcasite.s3.us-west-2.amazonaws.com/email_assets/orcasound_email_header.jpg" alt="Orcasound" align="center" container-background-color="#c4cdd3"></mj-image>
           </mj-column>
@@ -95,7 +95,6 @@ defmodule Orcasite.Notifications.Email do
           </mj-column>
         </mj-section>
 
-        <!-- footer -->
         <mj-section background-color="#5d5b72">
           <mj-column>
 

--- a/server/lib/orcasite/notifications/email.ex
+++ b/server/lib/orcasite/notifications/email.ex
@@ -51,10 +51,84 @@ defmodule Orcasite.Notifications.Email do
     </mj-body>
     </mjml>
     """
-    |> Zappa.compile!()
-    |> EEx.eval_string(Map.to_list(assigns))
-    |> Mjml.to_html()
-    |> elem(1)
+    |> compile_mjml(assigns)
+  end
+
+  def mjml_confirmed_candidate_body(assigns) do
+    assigns =
+      assigns
+      |> Map.put(
+        :unsubscribe_url,
+        url(~p"/auth/subscription/unsubscribe?token=#{assigns.unsubscribe_token}")
+      )
+
+    """
+    <mjml>
+      <mj-body>
+        <mj-section padding="0" full-width background-color="#c4cdd3">
+          <mj-column padding="0">
+            <mj-image src="https://orcasite.s3.us-west-2.amazonaws.com/email_assets/orcasound_email_header.jpg" alt="Orcasound" align="center" container-background-color="#c4cdd3"></mj-image>
+          </mj-column>
+        </mj-section>
+
+        <mj-section>
+          <mj-column background-color="#404040" padding="18px">
+            <mj-text font-size="14px" color="#F2F2F2" font-family="Helvetica" line-height="150%">
+              {{ message }}
+            </mj-text>
+          </mj-column>
+        </mj-section>
+
+        <mj-section>
+          <mj-column>
+            <mj-image src="https://orcasite.s3.us-west-2.amazonaws.com/email_assets/orcasound_dont_miss.jpg"></mj-image>
+
+            <mj-button href="http://live.orcasound.net/{{ node }}" background-color="#0F0F0F" border-radius="31px" font-size="18px" padding="18px" font-weight="bold">LISTEN NOW!</mj-button>
+          </mj-column>
+        </mj-section>
+
+        <mj-section>
+          <mj-column background-color="#404040">
+            <mj-text color="#F2F2F2" font-size="16px" align="center" line-height="150%" font-family="Helvetica">
+              If you miss the concert, <br /> watch the <a href="https://orcasound.net/blog?ecm" style="color: #007C89;">Orcasound blog</a> for recordings & bioacoustic analysis!
+            </mj-text>
+          </mj-column>
+        </mj-section>
+
+        <!-- footer -->
+        <mj-section background-color="#5d5b72">
+          <mj-column>
+
+            <mj-text font-weight="bold" font-family="Helvetica" color="#ffffff" align="center" line-height="150%">
+              If you encounter whales at sea, <a href="https://www.bewhalewise.org/" style="font-weight: normal; color: #ffffff">Be Whale Wise</a>.<br />
+              Know the laws and best practices in both the U.S. and Canada.
+            </mj-text>
+
+            <mj-divider border-color="#404040" border-width="1px"></mj-divider>
+
+            <mj-text color="#ffffff" font-size="12px" font-style="italic" align="center" line-height="150%">
+              Copyright © 2023 Orcasound, All rights reserved. <br />
+              You are receiving this email because you opted in via our website.
+            </mj-text>
+            <mj-text color="#ffffff" font-size="12px" align="center" line-height="150%">
+              <strong>Our mailing address is:</strong><br />
+              Orcasound<br />
+              7044 17th Ave NE<br />
+              Seattle, WA 98115-5739
+            </mj-text>
+            {{#if unsubscribe_token }}
+              <mj-text color="#ffffff" font-size="12px" align="center" line-height="150%">
+                If you no longer wish to receive these emails,<br />
+                you can <a href="{{ unsubscribe_url }}" style="color: #ffffff;">unsubscribe here</a>.
+              </mj-text>
+            {{/if}}
+          </mj-column>
+        </mj-section>
+
+      </mj-body>
+    </mjml>
+    """
+    |> compile_mjml(assigns)
   end
 
   def new_detection_body(assigns) do
@@ -95,7 +169,13 @@ defmodule Orcasite.Notifications.Email do
     |> to({name, email})
     |> from({"Orcasound", "info@orcasound.net"})
     |> subject("Listen to orcas near #{node_name}!")
-    |> html_body(new_detection_body(params |> Map.put(:node_name, node_name)))
+    |> html_body(
+      mjml_confirmed_candidate_body(
+        params
+        |> Map.put(:node_name, node_name)
+        |> Map.put(:message, "Orcas can be heard near #{node_name}!")
+      )
+    )
   end
 
   def confirmed_candidate_body(assigns) do
@@ -121,5 +201,13 @@ defmodule Orcasite.Notifications.Email do
     """
     |> Phoenix.HTML.Safe.to_iodata()
     |> List.to_string()
+  end
+
+  def compile_mjml(mjml, assigns) do
+    mjml
+    |> Zappa.compile!()
+    |> EEx.eval_string(Map.to_list(assigns))
+    |> Mjml.to_html()
+    |> elem(1)
   end
 end

--- a/server/mix.lock
+++ b/server/mix.lock
@@ -94,5 +94,5 @@
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
   "websock": {:hex, :websock, "0.5.2", "b3c08511d8d79ed2c2f589ff430bd1fe799bb389686dafce86d28801783d8351", [:mix], [], "hexpm", "925f5de22fca6813dfa980fb62fd542ec43a2d1a1f83d2caec907483fe66ff05"},
   "websock_adapter": {:hex, :websock_adapter, "0.5.3", "4908718e42e4a548fc20e00e70848620a92f11f7a6add8cf0886c4232267498d", [:mix], [{:bandit, ">= 0.6.0", [hex: :bandit, repo: "hexpm", optional: true]}, {:plug, "~> 1.14", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 2.6", [hex: :plug_cowboy, repo: "hexpm", optional: true]}, {:websock, "~> 0.5", [hex: :websock, repo: "hexpm", optional: false]}], "hexpm", "cbe5b814c1f86b6ea002b52dd99f345aeecf1a1a6964e209d208fb404d930d3d"},
-  "zappa": {:git, "https://github.com/fireproofsocks/zappa.git", "d89d983b73652e761861bd7c2c5d03a45fc4badd", [branch: "master"]},
+  "zappa": {:git, "https://github.com/skanderm/zappa.git", "d89d983b73652e761861bd7c2c5d03a45fc4badd", [branch: "master"]},
 }


### PR DESCRIPTION
Converts the header, CTA, and footer of the main confirmed candidate template to MJML. See: https://mjml.io/try-it-live/vD5iZTluB5

<img width="611" alt="image" src="https://github.com/orcasound/orcasite/assets/997770/430be1a5-ff4f-4567-920d-b12aed75058b">
<img width="624" alt="image" src="https://github.com/orcasound/orcasite/assets/997770/d69d80bc-4390-4367-b3a0-d2bdc1f79db6">
<img width="645" alt="image" src="https://github.com/orcasound/orcasite/assets/997770/825aeb0f-84ef-45d1-920a-8eff38eb39ee">
