### PR TITLE
Use correct getter for NotificationInstance

### DIFF
--- a/server/lib/orcasite/notifications/resources/subscription.ex
+++ b/server/lib/orcasite/notifications/resources/subscription.ex
@@ -106,15 +106,15 @@ defmodule Orcasite.Notifications.Subscription do
       argument :minutes_ago, :integer, default: 5
 
       filter expr(
-               (last_notification_id != ^arg(:notification_id) or last_notification_id == nil) and
+               active == true and
                  event_type == ^arg(:event_type) and
+                 (is_nil(last_notification_id) or last_notification_id != ^arg(:notification_id)) and
                  fragment(
                    "? is null or ? < timezone('UTC', now()) - ?::numeric * interval '1 minute'",
                    last_notified_at,
                    last_notified_at,
                    ^arg(:minutes_ago)
-                 ) and
-                 active == true
+                 )
              )
     end
   end

--- a/server/lib/orcasite/notifications/workers/send_notification_email.ex
+++ b/server/lib/orcasite/notifications/workers/send_notification_email.ex
@@ -10,16 +10,8 @@ defmodule Orcasite.Notifications.Workers.SendNotificationEmail do
       }) do
     notif_instance =
       NotificationInstance
-      |> Ash.Query.for_read(:read, %{id: notification_instance_id})
-      |> Notifications.read!()
-      |> Notifications.load([:notification, subscription: [:subscriber]])
-      |> case do
-        {:ok, notifs} when is_list(notifs) ->
-          notifs |> List.last()
-
-        {:ok, notif} ->
-          notif
-      end
+      |> Notifications.get!(notification_instance_id)
+      |> Notifications.load!([:notification, subscription: [:subscriber]])
 
     params =
       notif_instance.meta


### PR DESCRIPTION
Fixes an issue where the query was just returning all NotificationInstances and having the last one selected, sending all notifications to a single subscription.