### PR TITLE
Add JSON API for feeds with index route to /api/json/feeds

### DIFF
--- a/server/lib/orcasite/radio.ex
+++ b/server/lib/orcasite/radio.ex
@@ -1,5 +1,5 @@
 defmodule Orcasite.Radio do
-  use Ash.Api, extensions: [AshAdmin.Api, AshGraphql.Api]
+  use Ash.Api, extensions: [AshAdmin.Api, AshGraphql.Api, AshJsonApi.Api]
 
   resources do
     registry Orcasite.Radio.Registry
@@ -11,5 +11,9 @@ defmodule Orcasite.Radio do
 
   graphql do
     authorize? false
+  end
+
+  json_api do
+    log_errors? true
   end
 end

--- a/server/lib/orcasite/radio/feed.ex
+++ b/server/lib/orcasite/radio/feed.ex
@@ -1,6 +1,6 @@
 defmodule Orcasite.Radio.Feed do
   use Ash.Resource,
-    extensions: [AshAdmin.Resource, AshUUID, AshGraphql.Resource],
+    extensions: [AshAdmin.Resource, AshUUID, AshGraphql.Resource, AshJsonApi.Resource],
     data_layer: AshPostgres.DataLayer
 
   attributes do
@@ -109,6 +109,16 @@ defmodule Orcasite.Radio.Feed do
     queries do
       read_one :feed, :get_by_slug, allow_nil?: false
       list :feeds, :read
+    end
+  end
+
+  json_api do
+    type "feed"
+
+    routes do
+      base "/feeds"
+
+      index :read
     end
   end
 

--- a/server/lib/orcasite_web/json_api_router.ex
+++ b/server/lib/orcasite_web/json_api_router.ex
@@ -1,6 +1,6 @@
 defmodule OrcasiteWeb.JsonApiRouter do
   use AshJsonApi.Api.Router,
-    apis: [Orcasite.Notifications],
+    apis: [Orcasite.Notifications, Orcasite.Radio],
     json_schema: "/json_schema",
     open_api: "/open_api",
     modify_open_api: {__MODULE__, :modify_open_api, []}


### PR DESCRIPTION
Shows up in Redoc and Swagger docs at `/api/json/swaggerui` and `/api/json/redoc`. Query with:

```
curl -s -H "Content-Type: application/vnd.api+json" \
  -H "Accept: application/vnd.api+json" \
  http://localhost:4000/api/json/feeds
```

<img width="1507" alt="image" src="https://github.com/orcasound/orcasite/assets/997770/36881b0a-b055-411d-ac8b-adb2d17900b6">
<img width="1440" alt="image" src="https://github.com/orcasound/orcasite/assets/997770/452c7604-518a-49e1-9410-f9ce7a4df99c">
