### PR TITLE
Allow creating inactive subscription when creating a new subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,14 @@ The `POOL_SIZE` config var is necessary due to the current Postgres db having 20
 ## Emails
 
 Orcasite uses MJML for email templating. There are a few online MJML renderers, including: [mjml.io](https://mjml.io/try-it-live) and [grapes.js](https://grapesjs.com/demo-mjml.html)
+
+
+## API
+
+An API is available using the [JSON API spec](https://jsonapi.org/format/). For access to available endpoints, navigate to the server's `/api/json/swaggerui` or `/api/json/redoc` path for documentation and examples. As an example, you may access the full list of feeds with:
+
+```
+curl -s https://beta.orcasound.net/api/json/feeds \
+-H "Content-Type: application/vnd.api+json" \
+-H "Accept: application/vnd.api+json"
+```

--- a/server/lib/orcasite/notifications/resources/subscriber.ex
+++ b/server/lib/orcasite/notifications/resources/subscriber.ex
@@ -69,6 +69,7 @@ defmodule Orcasite.Notifications.Subscriber do
     create :confirmed_candidate_subscribe do
       argument :name, :string
       argument :email, :string
+      argument :response_data, :map
 
       # TODO: Remove this argument once we deploy to production.
       argument :active_subscription, :boolean, default: true
@@ -83,6 +84,7 @@ defmodule Orcasite.Notifications.Subscriber do
             _ -> %{}
           end
           |> Map.put(:email, Ash.Changeset.get_argument(changeset, :email))
+          |> Map.put(:response_data, Ash.Changeset.get_argument(changeset, :response_data))
 
         changeset
         |> Ash.Changeset.change_attribute(:meta, meta)

--- a/server/lib/orcasite/notifications/resources/subscriber.ex
+++ b/server/lib/orcasite/notifications/resources/subscriber.ex
@@ -70,6 +70,9 @@ defmodule Orcasite.Notifications.Subscriber do
       argument :name, :string
       argument :email, :string
 
+      # TODO: Remove this argument once we deploy to production.
+      argument :active_subscription, :boolean, default: true
+
       change set_attribute(:name, arg(:name))
       change set_attribute(:subscriber_type, :individual)
 
@@ -91,7 +94,9 @@ defmodule Orcasite.Notifications.Subscriber do
             meta: %{
               email: Ash.Changeset.get_argument(changeset, :email),
               name: Ash.Changeset.get_argument(changeset, :name)
-            }
+            },
+            # TODO: Remove this active field once we deploy to production.
+            active: Ash.Changeset.get_argument(changeset, :active_subscription)
           },
           type: :create
         )


### PR DESCRIPTION
This is for creating and testing the Google Form subscription hook. We want to create inactive subscriptions so we don't accidentally message people who are subscribing in production.