### PR TITLE
Remove redis persistence from docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,6 @@ services:
     restart: always
     ports:
       - "6379:6379"
-    command: redis-server --save 20 1 --loglevel warning
-    volumes:
-      - cache:/data
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     healthcheck:


### PR DESCRIPTION
Unnecessary since we don't need to persist between docker restarts