### PR TITLE
Add all necessary notification info in the oban job metadata 

### DIFF
--- a/server/lib/orcasite/notifications/resources/notification.ex
+++ b/server/lib/orcasite/notifications/resources/notification.ex
@@ -85,7 +85,7 @@ defmodule Orcasite.Notifications.Notification do
     create :notify_confirmed_candidate do
       description "Create a notification for confirmed candidate (i.e. detection group)"
       accept [:candidate_id]
-      argument :candidate_id, :integer
+      argument :candidate_id, :string
       argument :node, :string, allow_nil?: false
 
       argument :message, :string do

--- a/server/lib/orcasite/notifications/resources/notification_instance.ex
+++ b/server/lib/orcasite/notifications/resources/notification_instance.ex
@@ -62,7 +62,8 @@ defmodule Orcasite.Notifications.NotificationInstance do
           %{
             notification_instance_id: record.id,
             notification_id: record.notification_id,
-            subscription_id: record.subscription_id
+            subscription_id: record.subscription_id,
+            meta: record.meta
           }
           |> Orcasite.Notifications.Workers.SendNotificationEmail.new()
           |> Oban.insert()


### PR DESCRIPTION
Restarting the server currently causes notification jobs to fail, as the individual `NotificationInstances` are stored in memory. This change adds all necessary information for the job to succeed on server restart, as the job information is persisted by Oban as rows in the db (which get cleaned up later).