### PR TITLE
Add github actions for fast-forward merging

### DIFF
--- a/.github/workflows/fast-forward.yaml
+++ b/.github/workflows/fast-forward.yaml
@@ -1,0 +1,28 @@
+name: fast-forward
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  fast-forward:
+    # Only run if the comment contains the /fast-forward command.
+    if: ${{ contains(github.event.comment.body, '/fast-forward')
+      && github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Fast forwarding
+        uses: sequoia-pgp/fast-forward@v1
+        with:
+          merge: true
+          # To reduce the workflow's verbosity, use 'on-error'
+          # to only post a comment when an error occurs, or 'never' to
+          # never post a comment.  (In all cases the information is
+          # still available in the step's summary.)
+          comment: always

--- a/.github/workflows/fast-forward.yaml
+++ b/.github/workflows/fast-forward.yaml
@@ -1,4 +1,4 @@
-name: fast-forward
+name: Fast forward
 
 on:
   issue_comment:

--- a/.github/workflows/merge-validation.yaml
+++ b/.github/workflows/merge-validation.yaml
@@ -1,0 +1,16 @@
+name: Merge validation
+
+on:
+  pull_request:
+    branches:
+      - "prod"
+      - "stage"
+
+jobs:
+  merge-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge validation
+        run: |
+          echo "This branch only accepts fast forward merges. To merge this PR, leave a comment with the /fast-forward command"
+          exit 1


### PR DESCRIPTION
Github doesn't support ff-only merges from the UI. Using workaround: https://github.com/marketplace/actions/fast-forward-merge