### PR TITLE
Use step-security/harden-runner in github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/fast-forward.yaml
+++ b/.github/workflows/fast-forward.yaml
@@ -17,6 +17,10 @@ jobs:
       issues: write
 
     steps:
+      - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - name: Fast forwarding
         uses: sequoia-pgp/fast-forward@v1
         with:

--- a/.github/workflows/heroku.yaml
+++ b/.github/workflows/heroku.yaml
@@ -12,6 +12,10 @@ jobs:
     if: github.event.deployment_status.state != 'pending'
 
     steps:
+      - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       # Forward deployment's status to the deployed commit.
       - uses: octokit/request-action@v2.x
         env:
@@ -34,6 +38,10 @@ jobs:
 
     # Check that the deployed app returns successful HTTP response.
     steps:
+      - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - id: health_check
         uses: jtalk/url-health-check-action@v4
         with:


### PR DESCRIPTION
Turning on harden-runner in "audit" mode is the first step in hardening github workflow jobs.
The second step will be to enable "block" mode, which can be seen as the results of the first run:
https://app.stepsecurity.io/github/orcasound/orcasite/actions/runs/9293630393?jobid=25577205636&tab=recommendations

For more details see https://github.com/step-security/harden-runner