### PR TITLE
Add command to manually refresh Heroku status in PRs

### DIFF
--- a/.github/workflows/heroku.yaml
+++ b/.github/workflows/heroku.yaml
@@ -1,15 +1,20 @@
-name: Heroku
 # Based on https://janjones.me/posts/github-action-heroku-deployment/
+name: Heroku
 
-on: deployment_status
+on:
+  deployment_status:
+  issue_comment:
+    types: [created, edited]
 
 jobs:
   deployment-status:
     name: Check deployment status
     runs-on: ubuntu-latest
 
-    # Continue only if some definitive status has been reported.
-    if: github.event.deployment_status.state != 'pending'
+    # Continue only if some definitive status has been reported. Also allow
+    # manual refresh of status checks by commenting '/refresh-heroku-status'.
+    if: ${{ github.event.deployment_status.state != 'pending'
+      || (contains(github.event.comment.body, '/refresh-heroku-status') && github.event.issue.pull_request) }}
 
     steps:
       # Forward deployment's status to the deployed commit.
@@ -29,8 +34,10 @@ jobs:
     name: Check site health
     runs-on: ubuntu-latest
 
-    # Run health check only if deployment succeeds.
-    if: github.event.deployment_status.state == 'success'
+    # Run health check only if deployment succeeds. Also allow manual refresh
+    # of status checks by commenting '/refresh-heroku-status'.
+    if: ${{ github.event.deployment_status.state == 'success'
+      || (contains(github.event.comment.body, '/refresh-heroku-status') && github.event.issue.pull_request) }}
 
     # Check that the deployed app returns successful HTTP response.
     steps:


### PR DESCRIPTION
Heroku status checks are set using the `deployment_status` GH action trigger, which for some reason [throws an error for PRs that come from forks](https://github.com/orgs/community/discussions/83015). As a result, the status checks never get updated which makes the PR non-mergable without bypassing the settings.

This PR adds a `/refresh-heroku-status` command that can be run by posting it in a PR comment. The command will trigger a manual update of the statuses and provide a workaround to the `deployment_status` error.