### PR TITLE
Enable ISR on feed pages with 60s revalidation

### DIFF
--- a/ui/src/pages/listen/[feed].tsx
+++ b/ui/src/pages/listen/[feed].tsx
@@ -100,6 +100,7 @@ export async function getStaticProps({ params }: { params: { feed: string } }) {
     props: {
       dehydratedState: dehydrate(queryClient),
     },
+    revalidate: 60,
   };
 }
 


### PR DESCRIPTION
This should allow pages to pick up changes to feeds table without having to rebuild the frontend (see [Next.js ISR docs](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration) for details)