### PR TITLE
Upgrade to heroku-24 stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "Orcasite",
   "website": "https://live.orcasound.net/",
   "repository": "https://github.com/orcasound/orcasite",
-  "stack": "heroku-22",
+  "stack": "heroku-24",
   "environments": {
     "review": {
       "buildpacks": [
@@ -10,7 +10,10 @@
           "url": "https://github.com/heroku/heroku-buildpack-inline"
         },
         {
-          "url": "https://github.com/HashNuke/heroku-buildpack-elixir"
+          "url": "https://github.com/heroku/heroku-buildpack-apt"
+        },
+        {
+          "url": "https://github.com/gigalixir/gigalixir-buildpack-elixir"
         },
         {
           "url": "https://github.com/gigalixir/gigalixir-buildpack-phoenix-static"

--- a/server/Aptfile
+++ b/server/Aptfile
@@ -1,0 +1,2 @@
+# Install git for use during heroku release phase (sometimes needed to run mix tasks)
+git


### PR DESCRIPTION
Upgrading to [heroku-24 stack](https://devcenter.heroku.com/articles/heroku-24-stack)

Git is no longer available at runtime:

> We made some tools that are typically only required during the build (such as GCC, Make, Git and system Python) available only at build time, rather than at app run time too.

This seems to cause problems with some mix tasks (e.g. when running `mix ecto.migrate` during release phase:

```
** (ErlangError) Erlang error: :enoent
    (elixir 1.15.6) lib/system.ex:1092: System.cmd("git", ["--git-dir=.git", "config", "remote.origin.url"], [cd: "/app/deps/zappa"])
    (mix 1.15.6) lib/mix/scm/git.ex:265: Mix.SCM.Git.get_rev_info/0
    (mix 1.15.6) lib/mix/scm/git.ex:75: anonymous fn/2 in Mix.SCM.Git.lock_status/1
    (elixir 1.15.6) lib/file.ex:1624: File.cd!/2
    (mix 1.15.6) lib/mix/dep.ex:432: Mix.Dep.check_lock/1
    (elixir 1.15.6) lib/enum.ex:1693: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.15.6) lib/enum.ex:1693: Enum."-map/2-lists^map/1-1-"/2
    (mix 1.15.6) lib/mix/tasks/deps.loadpaths.ex:75: Mix.Tasks.Deps.Loadpaths.deps_check/2
```

It may be worth investigating why `mix ecto.migrate` needs to run git, but for now the simplest solution is to manually make sure git is installed using [heroku-buildpack-apt](https://github.com/heroku/heroku-buildpack-apt), which uses the `Aptfile` to specify what to install.