### PR TITLE
Sort candidate page detection marks by timestamp

### DIFF
--- a/ui/src/components/DetectionsTable.tsx
+++ b/ui/src/components/DetectionsTable.tsx
@@ -75,7 +75,13 @@ export default function DetectionsTable({
       <DetectionsPlayer
         feed={feed}
         marks={detections
-          .sort((a, b) => a.id.localeCompare(b.id))
+          .sort(({ timestamp: a }, { timestamp: b }) => {
+            const date_a = new Date(a);
+            const date_b = new Date(b);
+
+            // Sort by timestamp, low to high
+            return +date_a - +date_b;
+          })
           .map((d, index) => ({
             label: (index + 1).toString(),
             value: Number((+d.playerOffset - +startOffset).toFixed(1)),


### PR DESCRIPTION
Fixes a bug where mark labels are shown out of order.

Example: https://live.orcasound.net/reports/cand_02xuSDzBykrE1DftuaFkcv
![image](https://github.com/user-attachments/assets/61942f55-10a3-47e7-91a9-f5cdb26392ff)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the sorting of detections to be based on timestamps, ensuring chronological order in the DetectionsTable.
	- Added display of detection timestamps in the table cells for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->