### PR TITLE
Update notification instance action default accepts

### DIFF
--- a/server/lib/orcasite/notifications/resources/notification_instance.ex
+++ b/server/lib/orcasite/notifications/resources/notification_instance.ex
@@ -43,7 +43,7 @@ defmodule Orcasite.Notifications.NotificationInstance do
   end
 
   actions do
-    defaults [:create, :read, :update, :destroy]
+    defaults [:read, :destroy, update: :*, create: :*]
 
     create :create_with_relationships do
       argument :subscription, :map

--- a/server/lib/orcasite/radio/audio_image.ex
+++ b/server/lib/orcasite/radio/audio_image.ex
@@ -167,6 +167,7 @@ defmodule Orcasite.Radio.AudioImage do
     end
 
     update :generate_spectrogram do
+      require_atomic? false
       change set_attribute(:status, :processing)
 
       change after_action(


### PR DESCRIPTION
Fixes issue with deployment where notification instances don't have the right attributes accepted:
<img width="529" alt="image" src="https://github.com/user-attachments/assets/3a9942e7-60a1-4671-8344-07831491c48a">
