### PR TITLE
Update README with Zulip link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Flive.orcasound.net)](https://live.orcasound.net)
 [![License](https://img.shields.io/github/license/orcasound/orcasite)](https://github.com/orcasound/orcasite/blob/master/LICENSE)
 
-[![Slack](https://img.shields.io/badge/slack-join%20chat-blue.svg?logo=slack)](https://join.slack.com/t/orcasound/shared_invite/zt-293mdpy47-El~xXZA6YmHOWoCzB~8WpQ)
+[![Zulip](https://img.shields.io/badge/zulip-join_chat-blue.svg)](https://orcasound.zulipchat.com/#narrow/channel/437031-orcasite)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/orcasound/orcasite/blob/master/CONTRIBUTING.md)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/orcasound/orcasite/badge)](https://scorecard.dev/viewer/?uri=github.com/orcasound/orcasite)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the chat platform badge in the README from Slack to Zulip, ensuring users have the correct link for joining the chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->