### PR TITLE
Update online status threshold to 5 minutes from 30 seconds

### DIFF
--- a/server/lib/orcasite/radio/feed.ex
+++ b/server/lib/orcasite/radio/feed.ex
@@ -76,7 +76,7 @@ defmodule Orcasite.Radio.Feed do
   aggregates do
     exists :online, :feed_segments do
       public? true
-      filter expr(inserted_at > ago(30, :second))
+      filter expr(inserted_at > ago(5, :minute))
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Extended the time window for determining "online" feed segments from 30 seconds to 5 minutes, improving the accuracy of online status detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->