### PR TITLE
Show affordance for closing nav menu on mobile

### DIFF
--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -115,6 +115,9 @@ function Mobile({
           onClose={handleMenuToggle}
           ModalProps={{
             keepMounted: true, // Better open performance on mobile.
+            BackdropProps: {
+              style: { backgroundColor: "transparent" },
+            },
           }}
           sx={{
             display: { xs: "block", sm: "none" },
@@ -122,6 +125,7 @@ function Mobile({
               boxSizing: "border-box",
               width: drawerWidth,
               backgroundColor: "base.main",
+              marginTop: "60px",
             },
             zIndex: (theme) => theme.zIndex.drawer + 1,
           }}
@@ -133,15 +137,6 @@ function Mobile({
             flexDirection="column"
             alignItems="center"
           >
-            <Box sx={{ my: 2 }}>
-              <Image
-                src={wordmark.src}
-                alt="Orcasound"
-                width={140}
-                height={60}
-                priority={true}
-              />
-            </Box>
             <Divider color="base.contrastText" />
             <List sx={{ maxWidth: (theme) => theme.breakpoints.values.sm }}>
               {navItems.map((item) => (
@@ -154,7 +149,7 @@ function Mobile({
                     <ListItemIcon
                       sx={{
                         color: "base.contrastText",
-                        displa: "flex",
+                        display: "flex",
                         justifyContent: "center",
                         opacity: 0.9,
                       }}

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -125,7 +125,7 @@ function Mobile({
               boxSizing: "border-box",
               width: drawerWidth,
               backgroundColor: "base.main",
-              marginTop: "60px",
+              marginTop: (theme) => `${theme.mixins.toolbar.minHeight}px`,
             },
             zIndex: (theme) => theme.zIndex.drawer + 1,
           }}


### PR DESCRIPTION
Saw that there's a PR on this since before, but I implemented a slightly different solution. Someone had already prepared for a toggle between hamburger and close icon, and I personally didn't love how the logo swiped in with the rest of the full screen menu from the left (or the logo being at two places in the code). Here I've removed the logo from the full screen menu and added a margin so that the OG logo is displayed regardless of full screen mobile menu or not, and removed drawer backdrop. Downside is hardcoded top margin, upside is neater code and better user experience (imo that is :)). 

Please tell me if you want me to modify anything, and also if this should hade stage as base rather than main.

Solve #279 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced the mobile navigation layout with a transparent background and increased top spacing to improve content alignment.
  - Refined the mobile view by removing the brand image for a cleaner interface.
  - Corrected a display property typo in the mobile navigation component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->