### PR TITLE
Add new bout button to candidate page

### DIFF
--- a/server/lib/orcasite/notifications/email.ex
+++ b/server/lib/orcasite/notifications/email.ex
@@ -51,6 +51,11 @@ defmodule Orcasite.Notifications.Email do
             Review here: <a href="https://live.orcasound.net/reports/{{meta["candidate_id"]}}?utm_source=email&utm_medium=email&utm_campaign=notifications">{{ meta["candidate_id"] }}</a>
           </mj-text>
         {{/if}}
+        {{#if node && meta["start_time"] && meta["category"] }}
+          <mj-text font-size="20px" font-family="helvetica">
+            <a href="https://live.orcasound.net/bouts/new/{{ node }}?time={{ meta["start_time"] }}&category={{ meta["category"] }}&utm_source=email&utm_medium=email&utm_campaign=notifications">Start a new bout</a>
+          </mj-text>
+        {{/if}}
 
         {{#if notifications_since_count > 0}}
           <mj-text font-size="20px" font-family="helvetica">

--- a/server/lib/orcasite/notifications/workers/send_notification_email.ex
+++ b/server/lib/orcasite/notifications/workers/send_notification_email.ex
@@ -97,5 +97,4 @@ defmodule Orcasite.Notifications.Workers.SendNotificationEmail do
         {k, v}
     end)
   end
-
 end

--- a/server/lib/orcasite/radio/candidate.ex
+++ b/server/lib/orcasite/radio/candidate.ex
@@ -37,6 +37,18 @@ defmodule Orcasite.Radio.Candidate do
 
   calculations do
     calculate :uuid, :string, {Orcasite.Radio.Calculations.DecodeUUID, []}
+
+    calculate :audio_category,
+              Orcasite.Types.AudioCategory,
+              expr(
+                cond do
+                  category == :whale -> :biophony
+                  category == :vessel -> :anthrophony
+                  category == :other -> :geophony
+                end
+              ) do
+      public? true
+    end
   end
 
   relationships do
@@ -179,7 +191,7 @@ defmodule Orcasite.Radio.Candidate do
 
   graphql do
     type :candidate
-    attribute_types [feed_id: :id]
+    attribute_types feed_id: :id
 
     queries do
       get :candidate, :read

--- a/server/lib/orcasite/radio/detection.ex
+++ b/server/lib/orcasite/radio/detection.ex
@@ -283,11 +283,9 @@ defmodule Orcasite.Radio.Detection do
           if Ash.Changeset.get_argument(changeset, :send_notifications) do
             Task.Supervisor.async_nolink(Orcasite.TaskSupervisor, fn ->
               Orcasite.Notifications.Notification.notify_new_detection(
-                detection.id,
-                detection.feed.slug,
-                detection.description,
-                detection.listener_count,
-                detection.candidate.id,
+                detection,
+                detection.candidate,
+                detection.feed,
                 authorize?: false
               )
             end)

--- a/ui/src/components/Bouts/BoutPage.tsx
+++ b/ui/src/components/Bouts/BoutPage.tsx
@@ -146,7 +146,7 @@ export default function BoutPage({
     min([
       now,
       roundToNearest(
-        max([targetTime, addMinutes(targetTime, timeBuffer)]),
+        max([targetTime, addMinutes(bout?.endTime ?? targetTime, timeBuffer)]),
         nearestMinutes * 60 * 1000,
         "ceil",
       ),

--- a/ui/src/graphql/generated/index.ts
+++ b/ui/src/graphql/generated/index.ts
@@ -491,6 +491,7 @@ export type CancelNotificationResult = {
 
 export type Candidate = {
   __typename?: "Candidate";
+  audioCategory?: Maybe<AudioCategory>;
   category?: Maybe<DetectionCategory>;
   detectionCount?: Maybe<Scalars["Int"]["output"]>;
   detections: Array<Detection>;
@@ -507,6 +508,17 @@ export type CandidateDetectionsArgs = {
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   offset?: InputMaybe<Scalars["Int"]["input"]>;
   sort?: InputMaybe<Array<InputMaybe<DetectionSortInput>>>;
+};
+
+export type CandidateFilterAudioCategory = {
+  eq?: InputMaybe<AudioCategory>;
+  greaterThan?: InputMaybe<AudioCategory>;
+  greaterThanOrEqual?: InputMaybe<AudioCategory>;
+  in?: InputMaybe<Array<AudioCategory>>;
+  isNil?: InputMaybe<Scalars["Boolean"]["input"]>;
+  lessThan?: InputMaybe<AudioCategory>;
+  lessThanOrEqual?: InputMaybe<AudioCategory>;
+  notEq?: InputMaybe<AudioCategory>;
 };
 
 export type CandidateFilterCategory = {
@@ -541,6 +553,7 @@ export type CandidateFilterId = {
 
 export type CandidateFilterInput = {
   and?: InputMaybe<Array<CandidateFilterInput>>;
+  audioCategory?: InputMaybe<CandidateFilterAudioCategory>;
   category?: InputMaybe<CandidateFilterCategory>;
   detectionCount?: InputMaybe<CandidateFilterDetectionCount>;
   detections?: InputMaybe<DetectionFilterInput>;
@@ -588,6 +601,7 @@ export type CandidateFilterVisible = {
 };
 
 export const CandidateSortField = {
+  AudioCategory: "AUDIO_CATEGORY",
   Category: "CATEGORY",
   DetectionCount: "DETECTION_COUNT",
   FeedId: "FEED_ID",

--- a/ui/src/pages/reports/[candidateId].tsx
+++ b/ui/src/pages/reports/[candidateId].tsx
@@ -1,4 +1,13 @@
-import { Box, Breadcrumbs, Chip, Link, Paper, Typography } from "@mui/material";
+import { Add } from "@mui/icons-material";
+import {
+  Box,
+  Breadcrumbs,
+  Button,
+  Chip,
+  Link,
+  Paper,
+  Typography,
+} from "@mui/material";
 import Head from "next/head";
 import { useRouter } from "next/router";
 
@@ -22,6 +31,14 @@ const CandidatePage: NextPageWithLayout = () => {
     analytics.reports.reportOpened(candidateId);
   }
 
+  const time = candidate && new Date(candidate.minTime).toISOString();
+  const categoryMap = {
+    WHALE: "biophony",
+    VESSEL: "anthrophony",
+    OTHER: "geophony",
+  };
+  const category = candidate?.category && categoryMap[candidate.category];
+
   return (
     <div>
       <Head>Report {candidateId} | Orcasound </Head>
@@ -36,19 +53,28 @@ const CandidatePage: NextPageWithLayout = () => {
 
         <Paper sx={{ marginTop: 4, overflow: "auto" }}>
           <Box p={5}>
-            <Box display="flex" justifyContent="space-between">
-              <Box>
+            <Box display="flex" justifyContent="space-between" mb={5}>
+              <Box display="flex" flexDirection="column" gap={1}>
                 <Typography variant="h4">Detections</Typography>
-                <Typography sx={{ marginBottom: 5 }} variant="body2">
-                  {candidate?.id}
-                </Typography>
+                <Box display="flex" gap={1} alignItems="center">
+                  {currentUser?.moderator && (
+                    <Chip
+                      variant="outlined"
+                      label={candidate?.visible ? "Visible" : "Hidden"}
+                    />
+                  )}
+                  <Typography variant="body2">{candidate?.id}</Typography>
+                </Box>
               </Box>
-              <Box>
-                {currentUser?.moderator && (
-                  <Chip
-                    variant="outlined"
-                    label={candidate?.visible ? "Visible" : "Hidden"}
-                  />
+              <Box display="flex" gap={1}>
+                {candidate && currentUser?.moderator && (
+                  <Link
+                    href={`/bouts/new/${candidate.feed.slug}?time=${time}&category=${category}`}
+                  >
+                    <Button size="small" variant="outlined" startIcon={<Add />}>
+                      New bout
+                    </Button>
+                  </Link>
                 )}
               </Box>
             </Box>


### PR DESCRIPTION
Also updates new detection email with new bout link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "New bout" button to candidate report pages, allowing moderators to quickly start a new bout with relevant details pre-filled.
  - Email notifications for new detections now include a direct "Start a new bout" link when applicable.

- **Improvements**
  - Enhanced timeline calculations on bout pages for more accurate end time handling.
  - Improved category mapping for candidate reports, displaying clearer audio category labels.

- **Bug Fixes**
  - Minor formatting and layout adjustments for better readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->