### PR TITLE
Fix audio image gen

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -91,7 +91,7 @@ config :orcasite, Oban,
   repo: Orcasite.Repo,
   # 7 day job retention
   plugins: [{Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60}],
-  queues: [default: 10, email: 10, feeds: 10, audio_images: 20]
+  queues: [default: 10, email: 10, feeds: 10, audio_images: 10]
 
 config :spark, :formatter,
   remove_parens?: true,

--- a/server/lib/orcasite/radio/audio_image.ex
+++ b/server/lib/orcasite/radio/audio_image.ex
@@ -102,6 +102,23 @@ defmodule Orcasite.Radio.AudioImage do
              )
     end
 
+    read :for_feed_subscription do
+      argument :feed_id, :string, allow_nil?: false
+      argument :start_time, :utc_datetime_usec, allow_nil?: false
+      argument :end_time, :utc_datetime_usec, allow_nil?: false
+
+      filter expr(
+               feed_id == ^arg(:feed_id) and
+                 fragment(
+                   "(?) <= (?) AND (?) >= (?)",
+                   start_time,
+                   ^arg(:end_time),
+                   end_time,
+                   ^arg(:start_time)
+                 )
+             )
+    end
+
     create :for_feed_segment do
       upsert? true
       upsert_identity :unique_audio_image
@@ -249,7 +266,7 @@ defmodule Orcasite.Radio.AudioImage do
       pubsub OrcasiteWeb.Endpoint
 
       subscribe :audio_image_updated do
-        read_action :for_feed
+        read_action :for_feed_subscription
         actions [:for_feed_segment, :update]
       end
     end


### PR DESCRIPTION
Reduce queue size for audio images (was causing pg pooling issues. Remove pagination from audio image subscription read query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the audio image update subscription to provide more efficient and responsive updates for feed subscribers.

- **Chores**
  - Adjusted background processing settings to optimize resource usage for audio image tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->