### PR TITLE
Fix max page size in candidate query to 1000

### DIFF
--- a/server/lib/orcasite/radio/candidate.ex
+++ b/server/lib/orcasite/radio/candidate.ex
@@ -92,6 +92,7 @@ defmodule Orcasite.Radio.Candidate do
         offset? true
         countable true
         default_limit 100
+        max_page_size 1000
       end
 
       prepare build(load: [:uuid], sort: [inserted_at: :desc])

--- a/ui/src/pages/reports/index.tsx
+++ b/ui/src/pages/reports/index.tsx
@@ -48,9 +48,10 @@ const DetectionsPage: NextPageWithLayout = () => {
   const { currentUser } = useGetCurrentUserQuery().data ?? {};
 
   // TODO: Filter by feed
+  const offset = page * rowsPerPage;
   const candidatesQuery = useCandidatesQuery({
     limit: rowsPerPage,
-    offset: page * rowsPerPage,
+    offset: offset,
     sort: [{ field: "MIN_TIME", order: "DESC" }],
   });
 
@@ -67,10 +68,11 @@ const DetectionsPage: NextPageWithLayout = () => {
       <main>
         <h1>Reports</h1>
 
-        <Paper elevation={1} sx={{ overflow: "auto" }}>
+        <Paper elevation={1} sx={{ overflow: "auto", mb: 2 }}>
           <Table>
             <TableHead>
               <TableRow>
+                <TableCell>#</TableCell>
                 <TableCell>ID</TableCell>
                 <TableCell>Node</TableCell>
                 <TableCell align="right">Detections</TableCell>
@@ -83,12 +85,13 @@ const DetectionsPage: NextPageWithLayout = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {candidates.map((candidate) => (
+              {candidates.map((candidate, index) => (
                 <TableRow
                   key={candidate.id}
                   hover={true}
                   sx={{ ...(!candidate.visible && { opacity: 0.5 }) }}
                 >
+                  <TableCell>{index + offset + 1}</TableCell>
                   <TableCell>{candidate.id}</TableCell>
                   <TableCell sx={{ whiteSpace: "nowrap" }}>
                     {candidate.feed.slug}
@@ -111,7 +114,10 @@ const DetectionsPage: NextPageWithLayout = () => {
                       )
                       .join(", ")}{" "}
                   </TableCell>
-                  <TableCell title={candidate.minTime.toString()}>
+                  <TableCell
+                    title={candidate.minTime.toString()}
+                    sx={{ wordWrap: "anywhere" }}
+                  >
                     {candidate.detections
                       .map((d) => d.description)
                       .filter((d) => typeof d !== "undefined" && d !== null)


### PR DESCRIPTION
Closes #839 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added row numbering to the candidates table, displaying a "#" column that numbers rows across all pages.
- **Improvements**
  - Enhanced table readability by adding a bottom margin and improved text wrapping for candidate descriptions.
- **Chores**
  - Set a maximum page size of 1000 for paginated candidate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->