### PR TITLE
Add pagination control to top of reports table

### DIFF
--- a/ui/src/pages/reports/index.tsx
+++ b/ui/src/pages/reports/index.tsx
@@ -68,6 +68,26 @@ const DetectionsPage: NextPageWithLayout = () => {
         <h1>Reports</h1>
 
         <Paper elevation={1} sx={{ overflow: "auto" }}>
+          <TablePagination
+            component="div"
+            count={candidatesQuery.data?.candidates?.count || 0}
+            page={page}
+            rowsPerPage={rowsPerPage}
+            onPageChange={(e, pg) => {
+              setPage(pg);
+            }}
+            onRowsPerPageChange={(e) => {
+              setRowsPerPage(Number(e.target.value));
+            }}
+            rowsPerPageOptions={[10, 50, 100, 1000]}
+            sx={{
+              borderBottom: 1,
+              borderColor: "divider",
+              display: "flex",
+              justifyContent: "flex-end",
+              alignItems: "center",
+            }}
+          />
           <Table>
             <TableHead>
               <TableRow>


### PR DESCRIPTION
In reference to issue #838

https://github.com/orcasound/orcasite/issues/838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a pagination control above the reports table, allowing users to select the number of rows per page (10, 50, 100, 1000) and navigate pages from the top of the table.
- **Style**
  - Updated pagination controls with right alignment and a bottom border for improved appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->