### PR TITLE
Download bout audio

### DIFF
--- a/server/lib/orcasite/radio/bout.ex
+++ b/server/lib/orcasite/radio/bout.ex
@@ -42,6 +42,13 @@ defmodule Orcasite.Radio.Bout do
     update_timestamp :updated_at
   end
 
+  calculations do
+    calculate :export_json, :string, Orcasite.Radio.Calculations.BoutExportJson do
+      public? true
+      description "JSON file for exporting the bout and its feed segments"
+    end
+  end
+
   relationships do
     belongs_to :created_by_user, Orcasite.Accounts.User
 
@@ -63,6 +70,10 @@ defmodule Orcasite.Radio.Bout do
     many_to_many :tags, Orcasite.Radio.Tag do
       through Orcasite.Radio.ItemTag
       public? true
+    end
+
+    has_many :feed_segments, Orcasite.Radio.FeedSegment do
+      manual __MODULE__.Relationships.BoutFeedSegments
     end
   end
 

--- a/server/lib/orcasite/radio/bout.ex
+++ b/server/lib/orcasite/radio/bout.ex
@@ -17,14 +17,6 @@ defmodule Orcasite.Radio.Bout do
     end
   end
 
-  validations do
-    validate string_length(:name, min: 3), where: present(:name), before_action?: true
-  end
-
-  changes do
-    change set_attribute(:name, expr(string_trim(arg(:name)))), where: present(arg(:name))
-  end
-
   attributes do
     uuid_attribute :id, prefix: "bout", public?: true
 
@@ -47,7 +39,20 @@ defmodule Orcasite.Radio.Bout do
       public? true
       description "JSON file for exporting the bout and its feed segments"
     end
-    calculate :export_script, :string
+
+    calculate :export_json_file_name, :string, __MODULE__.Calculations.BoutExportJsonFileName do
+      public? true
+    end
+
+    calculate :export_script, :string, __MODULE__.Calculations.BoutExportScript do
+      public? true
+    end
+
+    calculate :export_script_file_name,
+              :string,
+              __MODULE__.Calculations.BoutExportScriptFileName do
+      public? true
+    end
   end
 
   relationships do
@@ -75,6 +80,7 @@ defmodule Orcasite.Radio.Bout do
 
     has_many :feed_segments, Orcasite.Radio.FeedSegment do
       manual __MODULE__.Relationships.BoutFeedSegments
+      public? true
     end
   end
 
@@ -175,6 +181,25 @@ defmodule Orcasite.Radio.Bout do
     end
   end
 
+  changes do
+    change set_attribute(:name, expr(string_trim(arg(:name)))), where: present(arg(:name))
+  end
+
+  validations do
+    validate string_length(:name, min: 3), where: present(:name), before_action?: true
+  end
+
+  json_api do
+    type "bout"
+
+    includes [:feed, :tags]
+
+    routes do
+      base "/bouts"
+      index :index
+    end
+  end
+
   graphql do
     type :bout
     attribute_types feed_id: :id, feed_stream_id: :id
@@ -187,17 +212,6 @@ defmodule Orcasite.Radio.Bout do
     mutations do
       create :create_bout, :create
       update :update_bout, :update
-    end
-  end
-
-  json_api do
-    type "bout"
-
-    includes [:feed, :tags]
-
-    routes do
-      base "/bouts"
-      index :index
     end
   end
 end

--- a/server/lib/orcasite/radio/bout.ex
+++ b/server/lib/orcasite/radio/bout.ex
@@ -43,10 +43,11 @@ defmodule Orcasite.Radio.Bout do
   end
 
   calculations do
-    calculate :export_json, :string, Orcasite.Radio.Calculations.BoutExportJson do
+    calculate :export_json, :string, __MODULE__.Calculations.BoutExportJson do
       public? true
       description "JSON file for exporting the bout and its feed segments"
     end
+    calculate :export_script, :string
   end
 
   relationships do

--- a/server/lib/orcasite/radio/bout/calculations/bout_export_json.ex
+++ b/server/lib/orcasite/radio/bout/calculations/bout_export_json.ex
@@ -1,8 +1,20 @@
-defmodule Orcasite.Radio.Calculations.BoutExportJson do
+defmodule Orcasite.Radio.Bout.Calculations.BoutExportJson do
   use Ash.Resource.Calculation
 
-  def load(_, _, _), do: [:feed_segments, feed: [:slug]]
+  @impl Ash.Resource.Calculation
+  def load(_, _, _),
+    do: [
+      :id,
+      :name,
+      :start_time,
+      :end_time,
+      :duration,
+      :category,
+      feed_segments: [:id, :feed_id, :start_time, :end_time, :duration, :file_name, :s3_url],
+      feed: [:slug]
+    ]
 
+  @impl Ash.Resource.Calculation
   def calculate(records, _opts, _context) do
     records
     |> Enum.map(fn bout ->
@@ -16,12 +28,12 @@ defmodule Orcasite.Radio.Calculations.BoutExportJson do
         segments
         |> Enum.map(fn seg ->
           seg
-          |> Ash.load!(:s3_url)
           |> Map.take([:id, :feed_id, :start_time, :end_time, :duration, :file_name, :s3_url])
           |> Map.put(:feed_slug, bout.feed.slug)
         end)
       )
       |> Jason.encode!()
     end)
+    |> then(&{:ok, &1})
   end
 end

--- a/server/lib/orcasite/radio/bout/calculations/bout_export_json.ex
+++ b/server/lib/orcasite/radio/bout/calculations/bout_export_json.ex
@@ -10,6 +10,7 @@ defmodule Orcasite.Radio.Calculations.BoutExportJson do
 
       bout
       |> Map.take([:id, :name, :start_time, :end_time, :duration, :category])
+      |> Map.put(:feed_segments_count, Enum.count(segments))
       |> Map.put(
         :feed_segments,
         segments

--- a/server/lib/orcasite/radio/bout/calculations/bout_export_json_file_name.ex
+++ b/server/lib/orcasite/radio/bout/calculations/bout_export_json_file_name.ex
@@ -1,0 +1,12 @@
+defmodule Orcasite.Radio.Bout.Calculations.BoutExportJsonFileName do
+  use Ash.Resource.Calculation
+
+  @impl Ash.Resource.Calculation
+  def calculate(records, _opts, _context) do
+    Enum.map(records, fn bout ->
+      # Use manual calculation to get encoded ids, e.g.
+      # "bout_02yvkc7AvrVDIdCChlSwzP"
+      bout.id <> ".json"
+    end)
+  end
+end

--- a/server/lib/orcasite/radio/bout/calculations/bout_export_json_file_name.ex
+++ b/server/lib/orcasite/radio/bout/calculations/bout_export_json_file_name.ex
@@ -6,7 +6,7 @@ defmodule Orcasite.Radio.Bout.Calculations.BoutExportJsonFileName do
     Enum.map(records, fn bout ->
       # Use manual calculation to get encoded ids, e.g.
       # "bout_02yvkc7AvrVDIdCChlSwzP"
-      bout.id <> ".json"
+      "orcasound_" <> bout.id <> ".json"
     end)
   end
 end

--- a/server/lib/orcasite/radio/bout/calculations/bout_export_script.ex
+++ b/server/lib/orcasite/radio/bout/calculations/bout_export_script.ex
@@ -1,12 +1,111 @@
 defmodule Orcasite.Radio.Bout.Calculations.BoutExportScript do
   use Ash.Resource.Calculation
 
+  @impl Ash.Resource.Calculation
   def calculate(records, _opts, _context) do
     # Python script to download the bout's audio and optionally transcode locally
     # with ffmpeg
     records
+    |> Enum.map(&export_script/1)
   end
 
-  def export_script(bout) do
+  def export_script(_bout) do
+    ~S|
+      # A Python script to download an audio bout from live.orcasound.net. This will download ~10 second
+      # .ts audio files in a bout-specific folder (orcasound_<bout_id>/) and use `ffmpeg` to combine them into a
+      # single audio file in the format specified by the 'ext' option. Example:
+      # `python <file_name> --ext mp4`
+      import json
+      import os
+      import urllib.request
+      import argparse
+      from progress.bar import Bar
+
+
+      def load_file(file_name):
+          with open(file_name, "r") as f:
+              bout_data = f.read()
+              return json.loads(bout_data)
+
+
+      def download_files(bout_json):
+          bout_id = bout_json["id"]
+          bout_ts_path = f"{bout_id}/ts"
+          os.makedirs(bout_ts_path, exist_ok=True)  # Requires python >= 3.5
+          feed_segments = bout_json["feed_segments"]
+          with Bar("Downloading files", max=len(feed_segments)) as bar:
+              for segment in feed_segments:
+                  file_name = segment["file_name"]
+                  file_path = f"{bout_ts_path}/{file_name}"
+                  if not os.path.exists(file_path):
+                      urllib.request.urlretrieve(segment["s3_url"], file_path)
+                  bar.next()
+
+
+      def combine_files(bout_json, output_ext):
+          """
+          Combines all ~10 second .ts audio files into one audio file
+          """
+          bout_id = bout_json["id"]
+          bout_path = bout_id
+          ts_path = "ts"
+          feed_segments = sorted(
+              bout_json["feed_segments"], key=lambda seg: seg["start_time"]
+          )
+          times = [seg["start_time"] for seg in feed_segments]
+          print(f"{times =}")
+          list_file = f"{bout_path}/segments.txt"
+
+          combined_path = f"{bout_path}/{bout_id}.{output_ext}"
+
+          write_list_file(feed_segments, ts_path, list_file)
+
+          os.system(
+              f"ffmpeg -fflags +igndts -f concat -safe 0 -i ./{list_file} -c copy ./{combined_path}"
+          )
+
+
+      def write_list_file(feed_segments, bout_ts_path, list_file):
+          """
+          Creates a list of file paths for ffmpeg to use
+          https://trac.ffmpeg.org/wiki/Concatenate#Instructions
+          """
+          with open(list_file, "w") as f:
+              for segment in feed_segments:
+                  file_path = f"{bout_ts_path}/{segment["file_name"]}"
+                  f.write(f"file '{file_path}'\n")
+
+
+      if __name__ == "__main__":
+          script_name = os.path.basename(__file__)
+          bout_id = script_name.split("__")[1].split(".")[0]
+
+          parser = argparse.ArgumentParser(
+              "download_bout",
+              description=f"""
+              A Python script to download an audio bout from live.orcasound.net. This will download ~10 second
+              .ts audio files in a bout-specific folder (orcasound_{bout_id}/) and use `ffmpeg` to combine them into a
+              single audio file in the format specified by the 'ext' option. Example:
+
+              `python {script_name} --ext mp4`
+              """,
+          )
+          parser.add_argument(
+              "ext",
+              help="Extension of the combined audio file (e.g. mp4, wav, ogg, flac, etc)",
+              type=str,
+              default="mp4",
+              const="mp4",
+              nargs="?",
+          )
+          args = parser.parse_args()
+          output = args.ext
+
+          file_name = f"orcasound_{bout_id}.json"
+          bout_json = load_file(file_name)
+
+          download_files(bout_json)
+          combine_files(bout_json, output)
+    | |> String.replace("\n      ", "\n")
   end
 end

--- a/server/lib/orcasite/radio/bout/calculations/bout_export_script.ex
+++ b/server/lib/orcasite/radio/bout/calculations/bout_export_script.ex
@@ -11,6 +11,7 @@ defmodule Orcasite.Radio.Bout.Calculations.BoutExportScript do
 
   def export_script(_bout) do
     ~S|
+      #!/usr/bin/env python3
       # A Python script to download an audio bout from live.orcasound.net. This will download ~10 second
       # .ts audio files in a bout-specific folder (orcasound_<bout_id>/) and use `ffmpeg` to combine them into a
       # single audio file in the format specified by the 'ext' option. Example:
@@ -56,7 +57,7 @@ defmodule Orcasite.Radio.Bout.Calculations.BoutExportScript do
           print(f"{times =}")
           list_file = f"{bout_path}/segments.txt"
 
-          combined_path = f"{bout_path}/{bout_id}.{output_ext}"
+          combined_path = f"{bout_id}.{output_ext}"
 
           write_list_file(feed_segments, ts_path, list_file)
 
@@ -106,6 +107,7 @@ defmodule Orcasite.Radio.Bout.Calculations.BoutExportScript do
 
           download_files(bout_json)
           combine_files(bout_json, output)
+          print(f"Bout file: {bout_id}.{output}")
     | |> String.replace("\n      ", "\n")
   end
 end

--- a/server/lib/orcasite/radio/bout/calculations/bout_export_script.ex
+++ b/server/lib/orcasite/radio/bout/calculations/bout_export_script.ex
@@ -1,0 +1,12 @@
+defmodule Orcasite.Radio.Bout.Calculations.BoutExportScript do
+  use Ash.Resource.Calculation
+
+  def calculate(records, _opts, _context) do
+    # Python script to download the bout's audio and optionally transcode locally
+    # with ffmpeg
+    records
+  end
+
+  def export_script(bout) do
+  end
+end

--- a/server/lib/orcasite/radio/bout/calculations/bout_export_script_file_name.ex
+++ b/server/lib/orcasite/radio/bout/calculations/bout_export_script_file_name.ex
@@ -1,0 +1,12 @@
+defmodule Orcasite.Radio.Bout.Calculations.BoutExportScriptFileName do
+  use Ash.Resource.Calculation
+
+  @impl Ash.Resource.Calculation
+  def calculate(records, _opts, _context) do
+    Enum.map(records, fn bout ->
+      # Use manual calculation to get encoded ids, e.g.
+      # "bout_02yvkc7AvrVDIdCChlSwzP"
+      "orcasound_download_bout__" <> bout.id <> ".py"
+    end)
+  end
+end

--- a/server/lib/orcasite/radio/bout/relationships/bout_feed_segments.ex
+++ b/server/lib/orcasite/radio/bout/relationships/bout_feed_segments.ex
@@ -1,0 +1,56 @@
+defmodule Orcasite.Radio.Bout.Relationships.BoutFeedSegments do
+  use Ash.Resource.ManualRelationship
+  require Ash.Query
+
+  @impl true
+  def load(records, _opts, context) do
+    feed_ids = Enum.map(records, & &1.feed_id)
+    min_time = Enum.map(records, & &1.start_time) |> Enum.min(Datetime, fn -> nil end)
+    max_time = Enum.map(records, & &1.end_time) |> Enum.max(Datetime, fn -> nil end)
+
+    # Start with %{bout_1_id => [], bout_2_id => [], ...}
+    start_acc = Enum.map(records, &{&1.id, []}) |> Enum.into(%{})
+
+    # Get all feed segments relevant to the bouts
+    Orcasite.Radio.FeedSegment
+    |> Ash.Query.new()
+    |> Ash.Query.filter(feed_id in ^feed_ids)
+    |> Ash.Query.filter(
+      fragment("(?) between (?) and (?)", start_time, ^min_time, ^max_time) or
+        fragment("(?) between (?) and (?)", end_time, ^min_time, ^max_time)
+    )
+    |> Ash.stream!(Ash.Context.to_opts(context))
+    # Pair up segments with any of the bouts
+    |> Stream.transform(nil, fn segment, nil ->
+      # Get bout ids for this segment
+      bout_ids =
+        records
+        |> Enum.flat_map(fn bout ->
+          if ranges_overlap?(bout, segment) do
+            [bout.id]
+          else
+            []
+          end
+        end)
+
+      {bout_ids |> Enum.map(&{&1, segment}), nil}
+    end)
+    # Create bout-grouped segments (i.e. %{bout_1_id => segments_1, bout_2_id => segments_2, ...})
+    |> Enum.reduce(start_acc, fn {bout_id, segment}, acc ->
+      acc
+      |> update_in([bout_id], &[segment | &1])
+    end)
+    # Sort segments by time
+    |> Enum.map(fn {bout_id, segments} -> {bout_id, Enum.sort_by(segments, & &1.start_time)} end)
+    |> Enum.into(%{})
+    |> then(&{:ok, &1})
+  end
+
+  def ranges_overlap?(bout, segment) do
+    if bout.start_time && bout.end_time && segment.start_time && segment.end_time do
+      # startTime1 <= endTime2 && startTime2 <= endTime1
+      DateTime.compare(bout.start_time, segment.end_time) != :gt &&
+        DateTime.compare(segment.start_time, bout.end_time) != :gt
+    end
+  end
+end

--- a/server/lib/orcasite/radio/bout/relationships/bout_feed_segments.ex
+++ b/server/lib/orcasite/radio/bout/relationships/bout_feed_segments.ex
@@ -2,48 +2,62 @@ defmodule Orcasite.Radio.Bout.Relationships.BoutFeedSegments do
   use Ash.Resource.ManualRelationship
   require Ash.Query
 
-  @impl true
+  @impl Ash.Resource.ManualRelationship
   def load(records, _opts, context) do
+    records = records |> Ash.load!([:start_time, :end_time])
     feed_ids = Enum.map(records, & &1.feed_id)
-    min_time = Enum.map(records, & &1.start_time) |> Enum.min(Datetime, fn -> nil end)
-    max_time = Enum.map(records, & &1.end_time) |> Enum.max(Datetime, fn -> nil end)
 
-    # Start with %{bout_1_id => [], bout_2_id => [], ...}
-    start_acc = Enum.map(records, &{&1.id, []}) |> Enum.into(%{})
+    min_time =
+      records
+      |> Enum.map(& &1.start_time)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.min(DateTime, fn -> nil end)
 
-    # Get all feed segments relevant to the bouts
-    Orcasite.Radio.FeedSegment
-    |> Ash.Query.new()
-    |> Ash.Query.filter(feed_id in ^feed_ids)
-    |> Ash.Query.filter(
-      fragment("(?) between (?) and (?)", start_time, ^min_time, ^max_time) or
-        fragment("(?) between (?) and (?)", end_time, ^min_time, ^max_time)
-    )
-    |> Ash.stream!(Ash.Context.to_opts(context))
-    # Pair up segments with any of the bouts
-    |> Stream.transform(nil, fn segment, nil ->
-      # Get bout ids for this segment
-      bout_ids =
-        records
-        |> Enum.flat_map(fn bout ->
-          if ranges_overlap?(bout, segment) do
-            [bout.id]
-          else
-            []
-          end
-        end)
+    max_time =
+      records
+      |> Enum.map(& &1.end_time)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.max(DateTime, fn -> nil end)
 
-      {bout_ids |> Enum.map(&{&1, segment}), nil}
-    end)
-    # Create bout-grouped segments (i.e. %{bout_1_id => segments_1, bout_2_id => segments_2, ...})
-    |> Enum.reduce(start_acc, fn {bout_id, segment}, acc ->
-      acc
-      |> update_in([bout_id], &[segment | &1])
-    end)
-    # Sort segments by time
-    |> Enum.map(fn {bout_id, segments} -> {bout_id, Enum.sort_by(segments, & &1.start_time)} end)
-    |> Enum.into(%{})
-    |> then(&{:ok, &1})
+    if min_time && max_time do
+      # Start with %{bout_1_id => [], bout_2_id => [], ...}
+      start_acc = Enum.map(records, &{&1.id, []}) |> Enum.into(%{})
+
+      # Get all feed segments relevant to the bouts
+      Orcasite.Radio.FeedSegment
+      |> Ash.Query.new()
+      |> Ash.Query.filter(feed_id in ^feed_ids)
+      |> Ash.Query.filter(
+        fragment("(?) <= (?) AND (?) >= (?)", start_time, ^max_time, end_time, ^min_time)
+      )
+      |> Ash.stream!(Ash.Context.to_opts(context))
+      # Pair up segments with any of the bouts
+      |> Stream.transform(nil, fn segment, nil ->
+        # Get bout ids for this segment
+        bout_ids =
+          records
+          |> Enum.flat_map(fn bout ->
+            if ranges_overlap?(bout, segment) do
+              [bout.id]
+            else
+              []
+            end
+          end)
+
+        {bout_ids |> Enum.map(&{&1, segment}), nil}
+      end)
+      # Create bout-grouped segments (i.e. %{bout_1_id => segments_1, bout_2_id => segments_2, ...})
+      |> Enum.reduce(start_acc, fn {bout_id, segment}, acc ->
+        acc
+        |> update_in([bout_id], &[segment | &1])
+      end)
+      # Sort segments by time
+      |> Enum.map(fn {bout_id, segments} -> {bout_id, Enum.sort_by(segments, & &1.start_time)} end)
+      |> Enum.into(%{})
+      |> then(&{:ok, &1})
+    else
+      {:ok, []}
+    end
   end
 
   def ranges_overlap?(bout, segment) do

--- a/server/lib/orcasite/radio/calculations/bout_export_json.ex
+++ b/server/lib/orcasite/radio/calculations/bout_export_json.ex
@@ -1,0 +1,26 @@
+defmodule Orcasite.Radio.Calculations.BoutExportJson do
+  use Ash.Resource.Calculation
+
+  def load(_, _, _), do: [:feed_segments, feed: [:slug]]
+
+  def calculate(records, _opts, _context) do
+    records
+    |> Enum.map(fn bout ->
+      segments = bout.feed_segments
+
+      bout
+      |> Map.take([:id, :name, :start_time, :end_time, :duration, :category])
+      |> Map.put(
+        :feed_segments,
+        segments
+        |> Enum.map(fn seg ->
+          seg
+          |> Ash.load!(:s3_url)
+          |> Map.take([:id, :feed_id, :start_time, :end_time, :duration, :file_name, :s3_url])
+          |> Map.put(:feed_slug, bout.feed.slug)
+        end)
+      )
+      |> Jason.encode!()
+    end)
+  end
+end

--- a/server/lib/orcasite/radio/feed_segment.ex
+++ b/server/lib/orcasite/radio/feed_segment.ex
@@ -67,6 +67,20 @@ defmodule Orcasite.Radio.FeedSegment do
     update_timestamp :updated_at
   end
 
+  calculations do
+    calculate :s3_url,
+              :string,
+              expr(
+                string_join([
+                  type("https://s3-", :string),
+                  bucket_region,
+                  type(".amazonaws.com/", :string),
+                  bucket,
+                  segment_path
+                ])
+              )
+  end
+
   relationships do
     belongs_to :feed, Orcasite.Radio.Feed, public?: true
     belongs_to :feed_stream, Orcasite.Radio.FeedStream, public?: true
@@ -119,6 +133,12 @@ defmodule Orcasite.Radio.FeedSegment do
                    ^arg(:start_time)
                  )
              )
+    end
+
+    read :for_bout do
+      argument :bout_id, :string, allow_nil?: false
+
+      prepare Orcasite.Radio.Preparations.FeedSegmentsForBout
     end
 
     create :create do

--- a/server/lib/orcasite/radio/preparations/feed_segments_for_bout.ex
+++ b/server/lib/orcasite/radio/preparations/feed_segments_for_bout.ex
@@ -1,0 +1,30 @@
+defmodule Orcasite.Radio.Preparations.FeedSegmentsForBout do
+  use Ash.Resource.Preparation
+
+  def prepare(query, _opts, _context) do
+    bout_id =
+      query
+      |> Ash.Query.get_argument(:bout_id)
+
+    bout = Orcasite.Radio.Bout |> Ash.get!(bout_id)
+
+    query
+    |> Ash.Query.filter(feed_id == ^bout.feed_id)
+    |> Ash.Query.filter(
+      expr(
+        fragment(
+          "(?) between (?) and (?)",
+          start_time,
+          ^bout.start_time,
+          ^bout.end_time
+        ) or
+          fragment(
+            "(?) between (?) and (?)",
+            end_time,
+            ^bout.start_time,
+            ^bout.end_time
+          )
+      )
+    )
+  end
+end

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -23,6 +23,7 @@
         "date-fns": "^4.1.0",
         "dotenv-cli": "^7.4.2",
         "graphql": "^16.9.0",
+        "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
         "leaflet-defaulticon-compatibility": "^0.1.2",
         "lodash": "^4.17.21",
@@ -7080,6 +7081,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immutable": {
       "version": "3.7.6",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
@@ -7906,6 +7913,54 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keycode": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
@@ -7962,6 +8017,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -9128,6 +9192,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -9936,8 +10006,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sharp": {
       "version": "0.33.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -31,6 +31,7 @@
     "date-fns": "^4.1.0",
     "dotenv-cli": "^7.4.2",
     "graphql": "^16.9.0",
+    "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
     "leaflet-defaulticon-compatibility": "^0.1.2",
     "lodash": "^4.17.21",

--- a/ui/src/components/Bouts/BoutExport.tsx
+++ b/ui/src/components/Bouts/BoutExport.tsx
@@ -1,0 +1,111 @@
+import { Download } from "@mui/icons-material";
+import { Box, IconButton, Popover, Typography } from "@mui/material";
+import JSZip from "jszip";
+import { useRef, useState } from "react";
+
+import { useBoutExportQuery } from "@/graphql/generated";
+
+export default function BoutExport({ boutId }: { boutId: string }) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+  const { refetch } = useBoutExportQuery({ boutId }, { enabled: false });
+
+  const handleClick = () => {
+    refetch().then(({ data }) => {
+      const bout = data?.bout;
+      if (bout) {
+        const {
+          exportJson,
+          exportJsonFileName,
+          exportScript,
+          exportScriptFileName,
+        } = bout;
+
+        if (
+          exportJson &&
+          exportJsonFileName &&
+          exportScript &&
+          exportScriptFileName
+        ) {
+          const zip = new JSZip();
+          zip.file(exportJsonFileName, exportJson);
+          zip.file(exportScriptFileName, exportScript);
+          zip.generateAsync({ type: "blob" }).then((content) => {
+            download(`orcasound_${bout.id}.zip`, content);
+          });
+
+          if (buttonRef.current) {
+            setAnchorEl(buttonRef.current);
+            if (timeoutRef.current) {
+              clearTimeout(timeoutRef.current);
+            }
+            timeoutRef.current = window.setTimeout(() => {
+              setAnchorEl(null);
+            }, 3000);
+          }
+        }
+      }
+    });
+  };
+
+  const open = Boolean(anchorEl);
+
+  const handleClose = () => {
+    setAnchorEl(null);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+  };
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      minWidth={120}
+    >
+      <Box>
+        <Typography variant="overline">Export bout</Typography>
+      </Box>
+      <Box>
+        <IconButton onClick={handleClick} title="Export bout" ref={buttonRef}>
+          <Download />
+        </IconButton>
+      </Box>
+
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "center",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+        disableAutoFocus
+        disableEnforceFocus
+      >
+        <Typography variant="subtitle2" sx={{ p: 2 }}>
+          Downloaded bout export script
+        </Typography>
+      </Popover>
+    </Box>
+  );
+}
+
+// via: https://gist.github.com/Lehoczky/241f046b05c54af65918676888fc783f
+function download(fileName: string, blob: Blob) {
+  const downloadAnchor = document.createElement("a");
+
+  downloadAnchor.download = fileName;
+  downloadAnchor.href = URL.createObjectURL(blob);
+  downloadAnchor.click();
+  setTimeout(() => {
+    URL.revokeObjectURL(downloadAnchor.href);
+    downloadAnchor.remove();
+  }, 200);
+}

--- a/ui/src/components/Bouts/BoutPage.tsx
+++ b/ui/src/components/Bouts/BoutPage.tsx
@@ -65,6 +65,7 @@ import { roundToNearest } from "@/utils/time";
 import CopyToClipboardButton from "../CopyToClipboard";
 import LoadingSpinner from "../LoadingSpinner";
 import { BoutDetectionsTable } from "./BoutDetectionsTable";
+import BoutExport from "./BoutExport";
 import { BoutNotifications } from "./BoutNotifications";
 import BoutScrubBar from "./BoutScrubBar";
 import { BoutTags } from "./BoutTags";
@@ -642,6 +643,7 @@ export default function BoutPage({
               </Box>
             </Box>
           )}
+          {bout?.startTime && bout.endTime && <BoutExport boutId={bout.id} />}
 
           {currentUser?.moderator && (
             <Box display="flex" alignItems="center" ml={{ sm: 0, md: "auto" }}>

--- a/ui/src/graphql/generated/index.ts
+++ b/ui/src/graphql/generated/index.ts
@@ -303,14 +303,27 @@ export type Bout = {
   category: AudioCategory;
   duration?: Maybe<Scalars["Decimal"]["output"]>;
   endTime?: Maybe<Scalars["DateTime"]["output"]>;
+  /** JSON file for exporting the bout and its feed segments */
+  exportJson?: Maybe<Scalars["String"]["output"]>;
+  exportJsonFileName?: Maybe<Scalars["String"]["output"]>;
+  exportScript?: Maybe<Scalars["String"]["output"]>;
+  exportScriptFileName?: Maybe<Scalars["String"]["output"]>;
   feed?: Maybe<Feed>;
   feedId?: Maybe<Scalars["ID"]["output"]>;
+  feedSegments: Array<FeedSegment>;
   feedStreams: Array<FeedStream>;
   id: Scalars["ID"]["output"];
   itemTags: Array<ItemTag>;
   name?: Maybe<Scalars["String"]["output"]>;
   startTime: Scalars["DateTime"]["output"];
   tags: Array<Tag>;
+};
+
+export type BoutFeedSegmentsArgs = {
+  filter?: InputMaybe<FeedSegmentFilterInput>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  sort?: InputMaybe<Array<InputMaybe<FeedSegmentSortInput>>>;
 };
 
 export type BoutFeedStreamsArgs = {
@@ -417,6 +430,7 @@ export type BoutFilterInput = {
   endTime?: InputMaybe<BoutFilterEndTime>;
   feed?: InputMaybe<FeedFilterInput>;
   feedId?: InputMaybe<BoutFilterFeedId>;
+  feedSegments?: InputMaybe<FeedSegmentFilterInput>;
   feedStreams?: InputMaybe<FeedStreamFilterInput>;
   id?: InputMaybe<BoutFilterId>;
   itemTags?: InputMaybe<ItemTagFilterInput>;
@@ -3125,6 +3139,22 @@ export type BoutQuery = {
   } | null;
 };
 
+export type BoutExportQueryVariables = Exact<{
+  boutId: Scalars["ID"]["input"];
+}>;
+
+export type BoutExportQuery = {
+  __typename?: "RootQueryType";
+  bout?: {
+    __typename?: "Bout";
+    id: string;
+    exportJson?: string | null;
+    exportJsonFileName?: string | null;
+    exportScript?: string | null;
+    exportScriptFileName?: string | null;
+  } | null;
+};
+
 export type CandidateQueryVariables = Exact<{
   id: Scalars["ID"]["input"];
 }>;
@@ -4630,6 +4660,54 @@ useBoutQuery.fetcher = (
   variables: BoutQueryVariables,
   options?: RequestInit["headers"],
 ) => fetcher<BoutQuery, BoutQueryVariables>(BoutDocument, variables, options);
+
+export const BoutExportDocument = `
+    query boutExport($boutId: ID!) {
+  bout(id: $boutId) {
+    id
+    exportJson
+    exportJsonFileName
+    exportScript
+    exportScriptFileName
+  }
+}
+    `;
+
+export const useBoutExportQuery = <TData = BoutExportQuery, TError = unknown>(
+  variables: BoutExportQueryVariables,
+  options?: Omit<
+    UseQueryOptions<BoutExportQuery, TError, TData>,
+    "queryKey"
+  > & {
+    queryKey?: UseQueryOptions<BoutExportQuery, TError, TData>["queryKey"];
+  },
+) => {
+  return useQuery<BoutExportQuery, TError, TData>({
+    queryKey: ["boutExport", variables],
+    queryFn: fetcher<BoutExportQuery, BoutExportQueryVariables>(
+      BoutExportDocument,
+      variables,
+    ),
+    ...options,
+  });
+};
+
+useBoutExportQuery.document = BoutExportDocument;
+
+useBoutExportQuery.getKey = (variables: BoutExportQueryVariables) => [
+  "boutExport",
+  variables,
+];
+
+useBoutExportQuery.fetcher = (
+  variables: BoutExportQueryVariables,
+  options?: RequestInit["headers"],
+) =>
+  fetcher<BoutExportQuery, BoutExportQueryVariables>(
+    BoutExportDocument,
+    variables,
+    options,
+  );
 
 export const CandidateDocument = `
     query candidate($id: ID!) {

--- a/ui/src/graphql/queries/getBoutExport.graphql
+++ b/ui/src/graphql/queries/getBoutExport.graphql
@@ -1,0 +1,9 @@
+query boutExport($boutId: ID!) {
+  bout(id: $boutId) {
+    id
+    exportJson
+    exportJsonFileName
+    exportScript
+    exportScriptFileName
+  }
+}


### PR DESCRIPTION
Adds an export button to the bouts page that downloads a zip file with bout json data and a python script. The python script downloads all .ts segments and uses `ffmpeg` locally to combine them into one file. Usage:

```shell
python download_bout__bout_02yvkXtvXUdLW1iXCeXYZR.py --ext mp4
```

![image](https://github.com/user-attachments/assets/2a291991-4c88-4e84-b85f-f8cdf5fbf6f5)

![image](https://github.com/user-attachments/assets/f992dd97-7f83-423c-887b-e4f202f729d1)

![image](https://github.com/user-attachments/assets/f2515b45-3546-4ca4-af63-4960b891507b)

