### PR TITLE
Update logged-out bout view to be more shareable

### DIFF
--- a/ui/src/components/Bouts/BoutPage.tsx
+++ b/ui/src/components/Bouts/BoutPage.tsx
@@ -133,8 +133,7 @@ export default function BoutPage({
   );
 
   const timeBuffer = 5; // minutes
-  // Snap to nearest 5 minutes
-  const nearestMinutes = 5;
+  const nearestMinutes = 15;
   const [timelineStartTime, setTimelineStartTime] = useState<Date>(
     roundToNearest(
       subMinutes(targetTime, timeBuffer),
@@ -522,15 +521,17 @@ export default function BoutPage({
               <Typography variant="overline">Bout start</Typography>
             </Box>
             <Box>
-              <IconButton
-                onClick={() =>
-                  (!boutEndTime || playerTime.current < boutEndTime) &&
-                  setBoutStartTime(playerTime.current)
-                }
-                title="Set bout start"
-              >
-                <Start />
-              </IconButton>
+              {currentUser?.moderator && (
+                <IconButton
+                  onClick={() =>
+                    (!boutEndTime || playerTime.current < boutEndTime) &&
+                    setBoutStartTime(playerTime.current)
+                  }
+                  title="Set bout start"
+                >
+                  <Start />
+                </IconButton>
+              )}
             </Box>
             {boutStartTime && (
               <Box>
@@ -566,15 +567,17 @@ export default function BoutPage({
               <Typography variant="overline">Bout end</Typography>
             </Box>
             <Box>
-              <IconButton
-                onClick={() =>
-                  (!boutStartTime || playerTime.current > boutStartTime) &&
-                  setBoutEndTime(playerTime.current)
-                }
-                title="Set bout end"
-              >
-                <Start sx={{ transform: "rotate(180deg)" }} />
-              </IconButton>
+              {currentUser?.moderator && (
+                <IconButton
+                  onClick={() =>
+                    (!boutStartTime || playerTime.current > boutStartTime) &&
+                    setBoutEndTime(playerTime.current)
+                  }
+                  title="Set bout end"
+                >
+                  <Start sx={{ transform: "rotate(180deg)" }} />
+                </IconButton>
+              )}
             </Box>
             {boutEndTime && (
               <Box>
@@ -588,13 +591,15 @@ export default function BoutPage({
                 >
                   {format(boutEndTime, "h:mm:ss")}
                 </Button>
-                <IconButton
-                  onClick={() => setBoutEndTime(undefined)}
-                  title="Clear bout end"
-                  size="small"
-                >
-                  <Clear fontSize="small" />
-                </IconButton>
+                {currentUser?.moderator && (
+                  <IconButton
+                    onClick={() => setBoutEndTime(undefined)}
+                    title="Clear bout end"
+                    size="small"
+                  >
+                    <Clear fontSize="small" />
+                  </IconButton>
+                )}
               </Box>
             )}
           </Box>


### PR DESCRIPTION
Addresses feedback about sharing bouts: https://orcasound.zulipchat.com/#narrow/channel/437031-orcasite/topic/Alphatesting.20new.20bout.20UI/near/525097872

1. Change bout timeline expansion to 15 minutes at a time
2. Show bout end/start time setting to only moderators

![image](https://github.com/user-attachments/assets/cd8c8990-bf98-44a6-a881-b19c8c8b0602)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Timeline start and end times now snap to 15-minute intervals instead of 5 minutes.

* **Access Control**
  * Controls for setting and clearing bout start/end times are now visible only to moderators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->