### PR TITLE
refactor: extract TablePagination into reusable TablePaginationWrapper component

### DIFF
--- a/ui/src/components/TablePaginationWrapper.tsx
+++ b/ui/src/components/TablePaginationWrapper.tsx
@@ -1,0 +1,52 @@
+import { TablePagination } from "@mui/material";
+import { ElementType } from "react";
+
+interface TablePaginationProps {
+  count: number;
+  page: number;
+  rowsPerPage: number;
+  onPageChange: (event: unknown, newPage: number) => void;
+  onRowsPerPageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  rowsPerPageOptions?: number[];
+  component?: ElementType;
+  sx?: object;
+  showTopBorder?: boolean;
+}
+
+const TablePaginationWrapper = ({
+  count,
+  page,
+  rowsPerPage,
+  onPageChange,
+  onRowsPerPageChange,
+  rowsPerPageOptions = [10, 50, 100, 1000],
+  component = "div",
+  sx = {},
+  showTopBorder = false,
+}: TablePaginationProps) => {
+  const defaultSx = showTopBorder
+    ? {
+        borderBottom: 1,
+        borderColor: "divider",
+        display: "flex",
+        justifyContent: "flex-end",
+        alignItems: "center",
+        ...sx,
+      }
+    : sx;
+
+  return (
+    <TablePagination
+      component={component}
+      count={count}
+      page={page}
+      rowsPerPage={rowsPerPage}
+      onPageChange={onPageChange}
+      onRowsPerPageChange={onRowsPerPageChange}
+      rowsPerPageOptions={rowsPerPageOptions}
+      sx={defaultSx}
+    />
+  );
+};
+
+export default TablePaginationWrapper;

--- a/ui/src/pages/reports/index.tsx
+++ b/ui/src/pages/reports/index.tsx
@@ -7,7 +7,6 @@ import {
   TableCell,
   TableFooter,
   TableHead,
-  TablePagination,
   TableRow,
 } from "@mui/material";
 import Head from "next/head";
@@ -15,6 +14,7 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 
 import { getSimpleLayout } from "@/components/layouts/SimpleLayout";
+import TablePaginationWrapper from "@/components/TablePaginationWrapper";
 import {
   CandidatesQuery,
   useCandidatesQuery,
@@ -67,10 +67,10 @@ const DetectionsPage: NextPageWithLayout = () => {
 
       <main>
         <h1>Reports</h1>
-        
+
         <Paper elevation={1} sx={{ overflow: "auto" }}>
           {candidatesQuery.isSuccess && (
-            <TablePagination
+            <TablePaginationWrapper
               component="div"
               count={candidatesQuery.data?.candidates?.count || 0}
               page={page}
@@ -82,15 +82,9 @@ const DetectionsPage: NextPageWithLayout = () => {
                 setRowsPerPage(Number(e.target.value));
               }}
               rowsPerPageOptions={[10, 50, 100, 1000]}
-              sx={{
-                borderBottom: 1,
-                borderColor: "divider",
-                display: "flex",
-                justifyContent: "flex-end",
-                alignItems: "center",
-              }}
+              showTopBorder={true}
             />
-           )}
+          )}
           <Table>
             <TableHead>
               <TableRow>
@@ -169,7 +163,7 @@ const DetectionsPage: NextPageWithLayout = () => {
             {candidatesQuery.isSuccess && (
               <TableFooter>
                 <TableRow>
-                  <TablePagination
+                  <TablePaginationWrapper
                     count={candidatesQuery.data?.candidates?.count || 0}
                     page={page}
                     rowsPerPage={rowsPerPage}


### PR DESCRIPTION
Refactor Reports page pagination elements into a separate component

- Create generic TablePaginationWrapper component in src/components/
- Replace duplicate TablePagination instances in reports page
- Component accepts standard pagination props (count, page, rowsPerPage, etc.)
- Supports configurable options: rowsPerPageOptions, component type, styling
- Completely data-agnostic - can be used for any table pagination needs
- Maintains existing functionality while improving code reusability
- Follows DRY principle by centralizing pagination logic

The wrapper component is designed to be generic and reusable across the application for any data type requiring table pagination (users, products, search results, analytics, etc.) without being tied to specific data structures or use cases.

It's named TablePaginationWrapper to avoid conflict with native MUI TablePagination