### PR TITLE
Set bout zoom factor on load

### DIFF
--- a/ui/src/components/Bouts/SpectrogramTimeline.tsx
+++ b/ui/src/components/Bouts/SpectrogramTimeline.tsx
@@ -28,7 +28,7 @@ import { TimelineTickerLayer } from "./TimelineTickerLayer";
 
 export const TICKER_HEIGHT = 30;
 const SPECTROGRAM_HEIGHT = 300;
-const PIXEL_ZOOM_FACTOR = 50;
+export const PIXEL_ZOOM_FACTOR = 50;
 
 export type SpectrogramControls = {
   goToTime: (time: Date) => void;
@@ -131,7 +131,6 @@ export default function SpectrogramTimeline({
   // Full spectrogram container
   const spectrogramWindow = useRef<HTMLDivElement | null>(null);
   const [isDragging, setIsDragging] = useState<boolean>(false);
-  const [zoomLevel, setZoomLevel] = useState<number>(8);
   const [windowStartTime, setWindowStartTimeUnthrottled] = useState<Date>();
   const [windowEndTime, setWindowEndTimeUnthrottled] = useState<Date>();
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -150,6 +149,14 @@ export default function SpectrogramTimeline({
     { trailing: false },
   );
 
+  const initialZoom = calculateInitialZoom({
+    playerTimeRef,
+    boutStartTime,
+    boutEndTime,
+    timelineEndTime,
+  });
+
+  const [zoomLevel, setZoomLevel] = useState<number>(initialZoom ?? 8);
   const minZoom = 2;
   const maxZoom = 1600;
 
@@ -470,4 +477,18 @@ export default function SpectrogramTimeline({
       </Box>
     </>
   );
+}
+
+function calculateInitialZoom({
+  playerTimeRef,
+  boutStartTime,
+  boutEndTime,
+  timelineEndTime,
+}: {
+  playerTimeRef: MutableRefObject<Date>;
+  boutStartTime?: Date;
+  boutEndTime?: Date;
+  timelineEndTime?: Date;
+}) {
+  return 8;
 }

--- a/ui/src/components/Bouts/SpectrogramTimeline.tsx
+++ b/ui/src/components/Bouts/SpectrogramTimeline.tsx
@@ -161,7 +161,7 @@ export default function SpectrogramTimeline({
         spectrogramWindow: spectrogramWindow.current,
       }),
     );
-  }, [boutStartTime, boutEndTime, spectrogramWindow]);
+  }, [boutStartTime, boutEndTime]);
 
   // X position of visible window relative to browser
   const windowStartX = useRef<number>(0);

--- a/ui/src/components/Bouts/SpectrogramTimeline.tsx
+++ b/ui/src/components/Bouts/SpectrogramTimeline.tsx
@@ -155,7 +155,11 @@ export default function SpectrogramTimeline({
 
   useEffect(() => {
     setZoomLevel(
-      calculateInitialZoom({ boutStartTime, boutEndTime, spectrogramWindow }),
+      calculateInitialZoom({
+        boutStartTime,
+        boutEndTime,
+        spectrogramWindow: spectrogramWindow.current,
+      }),
     );
   }, [boutStartTime, boutEndTime, spectrogramWindow]);
 
@@ -487,16 +491,16 @@ function calculateInitialZoom({
 }: {
   boutStartTime?: Date;
   boutEndTime?: Date;
-  spectrogramWindow: MutableRefObject<HTMLDivElement | null>;
+  spectrogramWindow: HTMLDivElement | null;
 }) {
-  if (boutStartTime && boutEndTime && spectrogramWindow.current) {
+  if (boutStartTime && boutEndTime && spectrogramWindow) {
     const boutDurationMinutes =
       differenceInMilliseconds(boutEndTime, boutStartTime) / 1000 / 60;
 
     const boutExtent = 0.4; // Cover about 40% of the window
     const targetWindowTime = boutDurationMinutes / boutExtent;
 
-    const windowWidth = spectrogramWindow.current.clientWidth;
+    const windowWidth = spectrogramWindow.clientWidth;
 
     // zoom_factor * zoom = pixelsPerMinute
     // targetWindowTime [minutes] * pixelsPerMinute = windowWidth


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The zoom level in the spectrogram timeline is now dynamically calculated based on the bout duration and container size, providing a more adaptive initial view.
  * The current zoom level is now visibly displayed in the interface.

* **Improvements**
  * Zoom controls now use consistent minimum and maximum limits, ensuring smoother and more predictable zooming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->