### PR TITLE
Hide /seed page when ENABLE_SEED_FROM_PROD is disabled

### DIFF
--- a/ui/src/pages/seed.tsx
+++ b/ui/src/pages/seed.tsx
@@ -310,20 +310,10 @@ function toLocalISOString(date: Date) {
 
 SeedPage.getLayout = getSimpleLayout;
 
-export default SeedPage;
-
-// Hide the seed page in production when ENABLE_SEED_FROM_PROD is false
 export async function getStaticProps() {
-  // Check if seeding from production is enabled
   const enableSeedFromProd = process.env.ENABLE_SEED_FROM_PROD === "true";
-
-  if (!enableSeedFromProd) {
-    return {
-      notFound: true,
-    };
-  }
-
-  return {
-    props: {}, // Return empty props when seeding is enabled
-  };
+  // Hide the seed page when `ENABLE_SEED_FROM_PROD` isn't enabled
+  return !enableSeedFromProd ? { notFound: true } : { props: {} };
 }
+
+export default SeedPage;

--- a/ui/src/pages/seed.tsx
+++ b/ui/src/pages/seed.tsx
@@ -311,3 +311,19 @@ function toLocalISOString(date: Date) {
 SeedPage.getLayout = getSimpleLayout;
 
 export default SeedPage;
+
+// Hide the seed page in production when ENABLE_SEED_FROM_PROD is false
+export async function getStaticProps() {
+  // Check if seeding from production is enabled
+  const enableSeedFromProd = process.env.ENABLE_SEED_FROM_PROD === "true";
+
+  if (!enableSeedFromProd) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {}, // Return empty props when seeding is enabled
+  };
+}


### PR DESCRIPTION
https://github.com/orcasound/orcasite/issues/858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The seed page is now automatically hidden in production unless explicitly enabled via an environment variable, improving security and control over page visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->