### PR TITLE
Fix audio image background width to span the full div

### DIFF
--- a/ui/src/components/Bouts/AudioImagesLayer.tsx
+++ b/ui/src/components/Bouts/AudioImagesLayer.tsx
@@ -90,7 +90,7 @@ export function AudioImagesLayer({
                 backgroundColor: (theme) => theme.palette.accent2.main,
                 ...(audioImage.status === "complete" && {
                   backgroundImage: `url('${audioImageUrl}')`,
-                  backgroundSize: "auto 100%",
+                  backgroundSize: "100% 100%",
                 }),
               }}
               display="flex"


### PR DESCRIPTION
Based on this comment, it looks like we were just showing whatever image width fit in the div: https://orcasound.zulipchat.com/#narrow/channel/437031-orcasite/topic/Alphatesting.20new.20bout.20UI/near/529537269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the display of audio images to ensure they fully cover their container when loading is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->