### PR TITLE
Move spectrogram generation AWS API call to outside of a transaction

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -91,7 +91,7 @@ config :orcasite, Oban,
   repo: Orcasite.Repo,
   # 7 day job retention
   plugins: [{Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60}, {Oban.Plugins.Cron, []}],
-  queues: [default: 10, seed: 2, email: 10, feeds: 10, audio_images: 10]
+  queues: [default: 10, seed: 2, email: 10, feeds: 10, audio_images: 20]
 
 config :spark, :formatter,
   remove_parens?: true,

--- a/server/lib/orcasite/radio/audio_image.ex
+++ b/server/lib/orcasite/radio/audio_image.ex
@@ -81,6 +81,10 @@ defmodule Orcasite.Radio.AudioImage do
     end
   end
 
+  code_interface do
+    define :generate_spectrogram
+  end
+
   actions do
     defaults [:read, :destroy, create: :*, update: :*]
 
@@ -260,7 +264,7 @@ defmodule Orcasite.Radio.AudioImage do
       require_atomic? false
       change set_attribute(:status, :processing)
 
-      change after_action(fn _change, image, _context ->
+      change after_transaction(fn _change, {:ok, image}, _context ->
                # Only one feed segment at a time for now
                [feed_segment] = image |> Ash.load!(:feed_segments) |> Map.get(:feed_segments)
 

--- a/server/lib/orcasite/radio/feed.ex
+++ b/server/lib/orcasite/radio/feed.ex
@@ -289,13 +289,14 @@ defmodule Orcasite.Radio.Feed do
                # we can change this to a single spectrogram with all those audio segments
 
                feed_segments =
-                 Orcasite.Radio.FeedSegment
-                 |> Ash.Query.for_read(:for_feed_range, %{
-                   feed_id: change.data.id,
-                   start_time: change.arguments.start_time,
-                   end_time: change.arguments.end_time
-                 })
-                 |> Ash.read!(authorize?: false)
+                 Orcasite.Radio.FeedSegment.for_feed_range!(
+                   %{
+                     feed_id: change.data.id,
+                     start_time: change.arguments.start_time,
+                     end_time: change.arguments.end_time
+                   },
+                   authorize?: false
+                 )
 
                audio_image_inputs = feed_segments |> Enum.map(&%{feed_segment_id: &1.id})
 

--- a/server/lib/orcasite/radio/feed_segment.ex
+++ b/server/lib/orcasite/radio/feed_segment.ex
@@ -102,6 +102,10 @@ defmodule Orcasite.Radio.FeedSegment do
     end
   end
 
+  code_interface do
+    define :for_feed_range
+  end
+
   actions do
     defaults [:read, :update, :destroy]
 


### PR DESCRIPTION
AudioImage/spectrogram generation was getting bottlenecked by needing to be in a postgres transaction (where we have limited db connections). This allows the long AWS call (anywhere from 3s to 90s) to get done outside of the transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new interfaces for spectrogram generation and feed segment range retrieval, enabling improved audio image processing.

* **Improvements**
  * Increased processing capacity for audio image jobs, allowing more tasks to run concurrently and enhancing overall performance.

* **Refactor**
  * Streamlined how feed segments are retrieved for spectrogram generation, improving efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->