### PR TITLE
Add timeout to seed job, add 'latest' seeding of records to scheduled jobs

### DIFF
--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -90,7 +90,11 @@ config :mime, :extensions, %{
 config :orcasite, Oban,
   repo: Orcasite.Repo,
   # 7 day job retention
-  plugins: [{Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60}, {Oban.Plugins.Cron, []}],
+  plugins: [
+    Oban.Plugins.Lifeline,
+    Oban.Plugins.Cron,
+    {Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60}
+  ],
   queues: [default: 10, seed: 2, email: 10, feeds: 10, audio_images: 20]
 
 config :spark, :formatter,

--- a/server/lib/orcasite/radio/seed.ex
+++ b/server/lib/orcasite/radio/seed.ex
@@ -202,14 +202,12 @@ defmodule Orcasite.Radio.Seed do
         schedule :time_range, "* * * * *" do
           action :time_range
           queue :seed
-          timeout 60_000
           worker_module_name __MODULE__.AshOban.TimeRange.Worker
         end
 
         schedule :latest, "@hourly" do
           action :latest
           queue :seed
-          timeout 60_000
           worker_module_name __MODULE__.AshOban.Latest.Worker
         end
 
@@ -217,7 +215,6 @@ defmodule Orcasite.Radio.Seed do
           schedule :delete_old, "@hourly" do
             action :delete_old
             queue :seed
-            timeout 60_000
             worker_module_name __MODULE__.AshOban.DeleteOld.Worker
           end
         end

--- a/server/priv/repo/seeds.exs
+++ b/server/priv/repo/seeds.exs
@@ -1,6 +1,6 @@
 require Ash.Query
 
-Orcasite.Radio.Seed.all(%{
+Orcasite.Radio.Seed.time_range(%{
   end_time: DateTime.utc_now(),
   start_time: DateTime.add(DateTime.utc_now(), -1, :hour)
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified and renamed the seeding action to "time_range" for a more consistent interface.
  * Updated scheduled jobs and GraphQL mutations to use the new "time_range" action.
  * Improved job scheduling with enhanced queue, timeout, and worker configurations.
  * Simplified processing by removing obsolete data mappings and streamlining result handling.
  * Enhanced background job management by adding new plugins for improved reliability and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->