### PR TITLE
Set maintainer_emails to nullable_field in graphql

### DIFF
--- a/server/lib/orcasite/radio/feed.ex
+++ b/server/lib/orcasite/radio/feed.ex
@@ -356,6 +356,7 @@ defmodule Orcasite.Radio.Feed do
 
   graphql do
     type :feed
+    nullable_fields [:maintainer_emails]
 
     queries do
       read_one :feed, :get_by_slug, allow_nil?: false

--- a/server/test/orcasite_web/graphql/radio_test.exs
+++ b/server/test/orcasite_web/graphql/radio_test.exs
@@ -71,4 +71,64 @@ defmodule OrcasiteWeb.RadioTest do
 
     assert "det_" <> _ = id
   end
+
+  describe "feeds query" do
+    test "succeeds for public fields", %{conn: conn, feed: %{id: feed_id, slug: feed_slug}} do
+      assert %{
+               "data" => %{
+                 "feeds" => [%{"id" => ^feed_id, "slug" => ^feed_slug}]
+               }
+             } =
+               conn
+               |> post("/graphql", %{
+                 "query" => """
+                 {
+                   feeds {
+                     id
+                     slug
+                   }
+                 }
+                 """
+               })
+               |> json_response(200)
+    end
+
+    test "succeeds for forbidden fields", %{conn: conn, feed: %{id: feed_id, slug: feed_slug}} do
+      assert %{
+               "data" => %{
+                 "feeds" => [
+                   %{
+                     "id" => ^feed_id,
+                     "maintainerEmails" => nil,
+                     "slug" => ^feed_slug
+                   }
+                 ]
+               },
+               "errors" => [
+                 %{
+                   "code" => "forbidden_field",
+                   "fields" => [],
+                   "locations" => [%{"column" => 5, "line" => 5}],
+                   "message" => "forbidden field",
+                   "path" => ["feeds", 0, "maintainerEmails"],
+                   "short_message" => "forbidden field",
+                   "vars" => %{}
+                 }
+               ]
+             } =
+               conn
+               |> post("/graphql", %{
+                 "query" => """
+                 {
+                   feeds {
+                     id
+                     slug
+                     maintainerEmails
+                   }
+                 }
+                 """
+               })
+               |> json_response(200)
+    end
+  end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GraphQL schema to allow the maintainer emails field to be nullable in feed queries.

* **Tests**
  * Added tests to verify correct behavior when querying public and forbidden fields in the feeds GraphQL endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->