### PR TITLE
feat: allow upserting machine detections on idempotency_key

### DIFF
--- a/server/lib/orcasite/radio/detection.ex
+++ b/server/lib/orcasite/radio/detection.ex
@@ -307,7 +307,7 @@ defmodule Orcasite.Radio.Detection do
       upsert_identity :idempotency_key
 
       accept [:timestamp, :feed_id, :description, :idempotency_key]
-      upsert_fields [:timestamp, :feed_id, :description, :playlist_timestamp, :player_offset]
+      upsert_fields [:timestamp, :description, :playlist_timestamp, :player_offset]
 
       change set_attribute(:user_id, actor(:id))
       change set_attribute(:source_ip, context(:actor_ip))

--- a/server/lib/orcasite/radio/detection.ex
+++ b/server/lib/orcasite/radio/detection.ex
@@ -303,7 +303,11 @@ defmodule Orcasite.Radio.Detection do
     end
 
     create :submit_machine_detection do
+      upsert? true
+      upsert_identity :idempotency_key
+
       accept [:timestamp, :feed_id, :description, :idempotency_key]
+      upsert_fields [:timestamp, :feed_id, :description, :playlist_timestamp, :player_offset]
 
       change set_attribute(:user_id, actor(:id))
       change set_attribute(:source_ip, context(:actor_ip))

--- a/server/test/support/conn_case.ex
+++ b/server/test/support/conn_case.ex
@@ -28,6 +28,8 @@ defmodule OrcasiteWeb.ConnCase do
       import Plug.Conn
       import Phoenix.ConnTest
       import OrcasiteWeb.ConnCase
+
+      import ExUnit.CaptureLog
     end
   end
 


### PR DESCRIPTION
This PR allows updating detections by using the idempotency_key as an upsert key. This will update description, timestamp attributes, and relevant candidate fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Idempotent detection submissions to prevent duplicates.
  * Detections can include a description field.

* **Improvements**
  * Candidate aggregation now recomputes detection counts and overall time range from all associated detections for more accurate summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->