### PR TITLE
fix: use first candidate result for associating/updating a detection's candidate

### DIFF
--- a/server/lib/orcasite/radio/detection/changes/update_candidate.ex
+++ b/server/lib/orcasite/radio/detection/changes/update_candidate.ex
@@ -28,7 +28,7 @@ defmodule Orcasite.Radio.Detection.Changes.UpdateCandidate do
             })
             |> Ash.create!()
 
-          [candidate] ->
+          [candidate | _] ->
             detections =
               candidate.detections
               |> Kernel.++([detection])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection candidate handling to properly manage multiple similar detections, including automatic deduplication by ID and accurate recalculation of detection metadata and time bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->