### PR TITLE
chore: use candidate that's closest to the detection

### DIFF
--- a/server/lib/orcasite/radio/detection/changes/update_candidate.ex
+++ b/server/lib/orcasite/radio/detection/changes/update_candidate.ex
@@ -28,7 +28,27 @@ defmodule Orcasite.Radio.Detection.Changes.UpdateCandidate do
             })
             |> Ash.create!()
 
-          [candidate | _] ->
+          candidates ->
+            # Choose candidate that's closest to detection's timestamps
+            candidate =
+              Enum.sort_by(
+                candidates,
+                fn candidate ->
+                  [
+                    {candidate.min_time, detection.start_time},
+                    {candidate.min_time, detection.end_time},
+                    {candidate.max_time, detection.start_time},
+                    {candidate.max_time, detection.end_time}
+                  ]
+                  |> Enum.map(fn {t1, t2} ->
+                    Kernel.abs(DateTime.diff(t1, t2, :millisecond))
+                  end)
+                  |> Enum.min()
+                end,
+                :asc
+              )
+              |> Enum.at(0)
+
             detections =
               candidate.detections
               |> Kernel.++([detection])

--- a/server/lib/orcasite/radio/detection/changes/update_candidate.ex
+++ b/server/lib/orcasite/radio/detection/changes/update_candidate.ex
@@ -31,23 +31,19 @@ defmodule Orcasite.Radio.Detection.Changes.UpdateCandidate do
           candidates ->
             # Choose candidate that's closest to detection's timestamps
             candidate =
-              Enum.sort_by(
+              Enum.min_by(
                 candidates,
                 fn candidate ->
                   [
-                    {candidate.min_time, detection.start_time},
-                    {candidate.min_time, detection.end_time},
-                    {candidate.max_time, detection.start_time},
-                    {candidate.max_time, detection.end_time}
+                    {candidate.min_time, detection.timestamp},
+                    {candidate.max_time, detection.timestamp}
                   ]
                   |> Enum.map(fn {t1, t2} ->
                     Kernel.abs(DateTime.diff(t1, t2, :millisecond))
                   end)
                   |> Enum.min()
-                end,
-                :asc
+                end
               )
-              |> Enum.at(0)
 
             detections =
               candidate.detections


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection matching to handle multiple candidate matches by selecting the nearest candidate based on timestamp proximity, ensuring updates apply to the most relevant candidate and improving accuracy of detection and metadata updates when several candidates exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->