### PR TITLE
fix: stop Heroku workflow from failing on every issue comment

### DIFF
--- a/.github/workflows/heroku.yaml
+++ b/.github/workflows/heroku.yaml
@@ -3,26 +3,22 @@ name: Heroku
 
 on:
   deployment_status:
-  issue_comment:
-    types: [created, edited]
 
 jobs:
   deployment-status:
     name: Check deployment status
     runs-on: ubuntu-latest
 
-    # Continue only if some definitive status has been reported. Also allow
-    # manual refresh of status checks by commenting '/refresh-heroku-status'.
-    if: ${{ github.event.deployment_status.state != 'pending'
-      || (contains(github.event.comment.body, '/refresh-heroku-status') && github.event.issue.pull_request) }}
+    # Continue only if some definitive status has been reported.
+    if: ${{ github.event.deployment_status.state != 'pending' }}
 
     steps:
-      - uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       # Forward deployment's status to the deployed commit.
-      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
+      - uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -38,19 +34,17 @@ jobs:
     name: Check site health
     runs-on: ubuntu-latest
 
-    # Run health check only if deployment succeeds. Also allow manual refresh
-    # of status checks by commenting '/refresh-heroku-status'.
-    if: ${{ github.event.deployment_status.state == 'success'
-      || (contains(github.event.comment.body, '/refresh-heroku-status') && github.event.issue.pull_request) }}
+    # Run health check only if deployment succeeds.
+    if: ${{ github.event.deployment_status.state == 'success' }}
 
     # Check that the deployed app returns successful HTTP response.
     steps:
-      - uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - id: health_check
-        uses: jtalk/url-health-check-action@b716ccb6645355dd9fcce8002ce460e5474f7f00 # v4
+        uses: jtalk/url-health-check-action@e7d5ebdc9027fbf494d2d034f3e8fc78f8b7a2b9 # v5
         with:
           url: ${{ github.event.deployment.payload.web_url }}
           follow-redirect: true
@@ -58,7 +52,7 @@ jobs:
           retry-delay: 30s
         continue-on-error: true
       # Set appropriate status to the deployed commit.
-      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
+      - uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Problem

The `Heroku` workflow fails on **every comment** posted anywhere in the repo — e.g. [this run](https://github.com/orcasound/orcasite/actions/runs/30414825888/job/90458927885).

The `issue_comment` trigger was there so that commenting `/refresh-heroku-status` on a PR would re-post the Heroku status checks. It never worked, and the guard didn't actually gate on the magic phrase:

```yaml
if: ${{ github.event.deployment_status.state != 'pending' || (...) }}
```

On an `issue_comment` event `github.event.deployment_status.state` is empty, and `'' != 'pending'` is **true** — so the first branch short-circuits and the job runs on any comment. It then builds the API route from `github.event.deployment.sha`, also empty on a comment event, yielding `POST /repos/orcasound/orcasite/statuses/` → `404 Not Found`.

Across the last 200 runs:

| Event | Success | Failure |
|---|---|---|
| `deployment_status` | 56 | 0 |
| `issue_comment` | 0 | 144 |

Zero successes on the comment path, ever.

## Fix

Removed the `issue_comment` trigger and both `/refresh-heroku-status` clauses. The feature isn't salvageable as written — a comment payload carries no deployment context to forward, so making it work would mean resolving the PR head SHA and then querying the deployments API for its latest status. Given nobody has had a working version of this to miss, deleting it seemed better than building it.

The `deployment_status` path — which works, and is still in active use for PR review apps — is untouched.

## Drive-by

Bumped the pinned actions, which were behind and producing the Node 20 deprecation warnings on this workflow:

- `step-security/harden-runner` v2.12.2 → v2.20.0
- `octokit/request-action` v2.4.0 → v3.0.0 (node24 runner)
- `jtalk/url-health-check-action` v4 → v5 (node24 runner; the inputs used here are unchanged in v5)

One cosmetic warning will remain: `Unexpected input(s) 'repository', 'state', ...`. `request-action`'s `action.yml` only declares `route` and `mediaType`, but the action reads every `INPUT_*` as a request parameter — that's by design, and it's why the 56 real runs succeeded.

## Testing

`deployment_status` can't be exercised from a PR branch, since the workflow that runs is the one on the target branch. The `deployment_status` job is byte-identical apart from the action SHAs, and the removed conditions only ever affected `issue_comment` runs. The real check is that this PR's own comments no longer spawn failing `Heroku` runs once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aef29UGmzgktdmpr9tFiCz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment status handling by removing outdated manual refresh behavior.
  * Health checks now report deployment outcomes more reliably.

* **Chores**
  * Updated deployment and health-check automation to use newer, security-pinned action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->