### PR TITLE
fix: show feed coordinates on admin show and edit pages

### DIFF
--- a/server/lib/orcasite/radio/calculations/lat_lng.ex
+++ b/server/lib/orcasite/radio/calculations/lat_lng.ex
@@ -10,10 +10,10 @@ defmodule Orcasite.Radio.Calculations.LatLng do
   def calculate(records, opts, _arguments) do
     return_type = Keyword.get(opts, :return_type, :map)
 
-    Enum.map(records, fn %{location_point: %{coordinates: {lng, lat}}} ->
+    Enum.map(records, fn %{location_point: %{coordinates: {lng, lat}} = point} ->
       case return_type do
         :map -> %{lat: lat, lng: lng}
-        :string -> "#{lat},#{lng}"
+        :string -> Orcasite.Types.Geometry.lat_lng_string(point)
         _ -> %{lat: lat, lng: lng}
       end
     end)

--- a/server/lib/orcasite/radio/feed.ex
+++ b/server/lib/orcasite/radio/feed.ex
@@ -274,6 +274,7 @@ defmodule Orcasite.Radio.Feed do
         description "A comma-separated string of longitude and latitude"
       end
 
+      change &prefill_lat_lng_string/2
       change &change_lat_lng/2
     end
 
@@ -366,6 +367,23 @@ defmodule Orcasite.Radio.Feed do
 
     mutations do
       update :generate_feed_spectrograms, :generate_spectrogram
+    end
+  end
+
+  # Forms built from this action (e.g. Ash Admin's edit page) render the
+  # lat_lng_string argument, which would otherwise start out empty since the
+  # coordinates live in the location_point attribute.
+  defp prefill_lat_lng_string(changeset, _context) do
+    case {Ash.Changeset.fetch_argument(changeset, :lat_lng_string),
+          Orcasite.Types.Geometry.lat_lng_string(Map.get(changeset.data, :location_point))} do
+      {{:ok, submitted}, _} when is_binary(submitted) ->
+        changeset
+
+      {_, current} when is_binary(current) ->
+        Ash.Changeset.set_argument(changeset, :lat_lng_string, current)
+
+      _ ->
+        changeset
     end
   end
 

--- a/server/lib/orcasite/types/geometry.ex
+++ b/server/lib/orcasite/types/geometry.ex
@@ -28,6 +28,20 @@ defmodule Orcasite.Types.Geometry do
   end
 
   def graphql_type(_), do: :json
+
+  @doc """
+  Formats a point as a comma-separated "latitude,longitude" string — the order
+  humans use, which is the reverse of the {longitude, latitude} order the
+  coordinates are stored in.
+  """
+  def lat_lng_string(%Geo.Point{coordinates: {lng, lat}}), do: "#{lat},#{lng}"
+  def lat_lng_string(_), do: nil
+end
+
+# Without this, rendering a point in a template (e.g. the Ash Admin show page)
+# raises Protocol.UndefinedError.
+defimpl Phoenix.HTML.Safe, for: Geo.Point do
+  def to_iodata(point), do: Orcasite.Types.Geometry.lat_lng_string(point) || ""
 end
 
 if Code.ensure_loaded?(Ecto.DevLogger) do

--- a/server/test/orcasite/radio/feed_test.exs
+++ b/server/test/orcasite/radio/feed_test.exs
@@ -1,0 +1,66 @@
+defmodule Orcasite.Radio.FeedTest do
+  @moduledoc """
+  Regression tests for https://github.com/orcasound/orcasite/issues/974.
+
+  The admin UI couldn't display a feed's coordinates: the show page rendered
+  `<display error>` (no `Phoenix.HTML.Safe` implementation for `Geo.Point`) and
+  the edit page rendered an empty "Lat Lng String" box (nothing seeded the
+  argument from the record being edited).
+  """
+
+  use Orcasite.DataCase, async: true
+
+  import Orcasite.Generators.Radio
+
+  @point %Geo.Point{coordinates: {-123.1735774, 48.5583362}, srid: 4326, properties: %{}}
+
+  describe "rendering a location point in a template" do
+    test "renders latitude and longitude" do
+      assert Phoenix.HTML.Safe.to_iodata(@point) == "48.5583362,-123.1735774"
+    end
+  end
+
+  describe "the lat_lng_string argument on update" do
+    setup do
+      %{feed: create_feed!(location_point: @point)}
+    end
+
+    test "is seeded with the feed's current coordinates", %{feed: feed} do
+      changeset = Ash.Changeset.for_update(feed, :update, %{}, authorize?: false)
+
+      assert Ash.Changeset.get_argument(changeset, :lat_lng_string) ==
+               "48.5583362,-123.1735774"
+    end
+
+    test "leaves the coordinates alone when another field is updated", %{feed: feed} do
+      assert {:ok, updated} =
+               feed
+               |> Ash.Changeset.for_update(:update, %{name: "Somewhere Else"}, authorize?: false)
+               |> Ash.update()
+
+      assert updated.name == "Somewhere Else"
+      assert updated.location_point == @point
+    end
+
+    test "still accepts new coordinates", %{feed: feed} do
+      assert {:ok, updated} =
+               feed
+               |> Ash.Changeset.for_update(:update, %{lat_lng_string: "47.6,-122.3"},
+                 authorize?: false
+               )
+               |> Ash.update()
+
+      assert %Geo.Point{coordinates: {-122.3, 47.6}} = updated.location_point
+    end
+
+    test "is rendered with the current coordinates in a form", %{feed: feed} do
+      form =
+        feed
+        |> AshPhoenix.Form.for_update(:update, domain: Orcasite.Radio, authorize?: false)
+        |> Phoenix.HTML.FormData.to_form([])
+
+      assert Phoenix.HTML.Form.input_value(form, :lat_lng_string) ==
+               "48.5583362,-123.1735774"
+    end
+  end
+end


### PR DESCRIPTION
Fixes #974.

Two separate causes behind the two symptoms:

**Show page said `<display error>`.** Ash Admin renders non-date attributes through `Phoenix.HTML.Safe`, which `Geo.Point` doesn't implement, so it raised and the surrounding rescue printed the literal `<display error>`. The index table is unaffected because it goes through the resource's `format_fields` instead — the show page only consults `format_fields` for date/time types ([show.ex](https://github.com/ash-project/ash_admin/blob/main/lib/ash_admin/components/resource/show.ex#L706-L716), still the case on `ash_admin` main, so this isn't fixed by upgrading). Implemented `Phoenix.HTML.Safe` for `Geo.Point`, rendering `latitude,longitude`.

**Edit page had a blank "Lat Lng String" box.** The `:update` action doesn't accept `location_point`; it takes a `lat_lng_string` argument that `change_lat_lng/2` parses into a point. Nothing seeded that argument from the record being edited, so the form rendered `nil`. Added a change that seeds it from the feed's current coordinates when it isn't supplied. Submitting the form unchanged re-parses the same coordinates, which `Ash.Changeset.change_attribute/3` drops as a no-op, so no spurious write.

Also pointed the `lat_lng_string` calculation at the new shared formatter, so display and edit can't drift apart. Its output is unchanged.

## Testing

New `server/test/orcasite/radio/feed_test.exs`. Reverting the two source changes fails 3 of its 5 tests, reproducing both reported symptoms (`Protocol.UndefinedError` for the point, `nil` for the form field). Full suite passes: 29 tests, 0 failures, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent latitude/longitude formatting for location values.
  * Update forms now display existing coordinates and accept coordinate changes.
  * Unchanged location data is preserved when updating other feed details.

* **Bug Fixes**
  * Improved handling of missing location values during feed updates.
  * Ensured location coordinates render correctly in forms and radio feed views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->