### PR TITLE
chore: route all reviews to the maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
 * @orcasound/orcasite-maintainers
-
-/server/ @skanderm
-/ui/ @paulcretu


### PR DESCRIPTION
Drops the two per-directory rules, leaving only the catch-all:

```
* @orcasound/orcasite-maintainers
```

**Why.** Path rules override the catch-all, so `/server/` was owned solely by @skanderm and `/ui/` solely by @paulcretu — and `main` requires code-owner review to merge (`require_code_owner_reviews: true`, `required_approving_review_count: 0`). Both of them have been away, so every PR touching either directory has been gated on one absent person; there are currently ~12 open PRs sitting in exactly that state. With just the catch-all, any maintainer can review any part of the repo, and team membership becomes the single place to adjust reviewers.

**Worth a look while we're here:** the `orcasite-maintainers` team is @rainhead, @skanderm, @paulcretu. If we want reviews to keep moving, @dthaler (admin) and @adrmac (write) are both active and eligible — adding them to the team is a separate change from this PR, but it's the one that actually widens the reviewer pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)