### PR TITLE
fix: give Tag and ItemTag a JSON:API type

### DIFF
--- a/server/lib/orcasite/radio/item_tag.ex
+++ b/server/lib/orcasite/radio/item_tag.ex
@@ -2,7 +2,7 @@ defmodule Orcasite.Radio.ItemTag do
   use Ash.Resource,
     otp_app: :orcasite,
     domain: Orcasite.Radio,
-    extensions: [AshAdmin.Resource, AshGraphql.Resource, AshUUID],
+    extensions: [AshAdmin.Resource, AshGraphql.Resource, AshJsonApi.Resource, AshUUID],
     data_layer: AshPostgres.DataLayer,
     authorizers: [Ash.Policy.Authorizer]
 
@@ -122,6 +122,11 @@ defmodule Orcasite.Radio.ItemTag do
         |> Ash.Changeset.manage_relationship(:user, current_user, type: :append)
       end
     end
+  end
+
+  json_api do
+    # No routes -- item tags are only ever reached as an include.
+    type "item_tag"
   end
 
   graphql do

--- a/server/lib/orcasite/radio/tag.ex
+++ b/server/lib/orcasite/radio/tag.ex
@@ -2,7 +2,7 @@ defmodule Orcasite.Radio.Tag do
   use Ash.Resource,
     otp_app: :orcasite,
     domain: Orcasite.Radio,
-    extensions: [AshAdmin.Resource, AshGraphql.Resource, AshSlug, AshUUID],
+    extensions: [AshAdmin.Resource, AshGraphql.Resource, AshJsonApi.Resource, AshSlug, AshUUID],
     data_layer: AshPostgres.DataLayer,
     authorizers: [Ash.Policy.Authorizer]
 
@@ -85,6 +85,13 @@ defmodule Orcasite.Radio.Tag do
 
       change slugify(:name, into: :slug)
     end
+  end
+
+  json_api do
+    # No routes -- tags are only ever reached as an include (e.g. from bouts).
+    # The type is still required so resource identifiers and included resources
+    # serialize with a non-null "type".
+    type "tag"
   end
 
   graphql do

--- a/server/test/orcasite_web/json_api/bouts_test.exs
+++ b/server/test/orcasite_web/json_api/bouts_test.exs
@@ -1,0 +1,54 @@
+defmodule OrcasiteWeb.JsonApi.BoutsTest do
+  use OrcasiteWeb.ConnCase, async: true
+
+  setup do
+    feed = Orcasite.Generators.Radio.create_feed!()
+    moderator = Orcasite.Generators.Accounts.create_user!(moderator: true)
+
+    bout =
+      Orcasite.Radio.Bout
+      |> Ash.Changeset.for_create(
+        :create,
+        %{
+          category: :biophony,
+          start_time: DateTime.utc_now(),
+          feed_id: feed.id
+        },
+        actor: moderator
+      )
+      |> Ash.create!()
+
+    Orcasite.Radio.ItemTag
+    |> Ash.Changeset.for_create(
+      :bout_tag,
+      %{
+        tag: %{name: "seagull", description: "Sounds like a seagull"},
+        bout: %{id: bout.id}
+      },
+      actor: moderator
+    )
+    |> Ash.create!()
+
+    [feed: feed, bout: bout]
+  end
+
+  describe "GET /api/json/bouts" do
+    test "includes a JSON:API type for tags", %{conn: conn, feed: feed} do
+      feed_id = feed.id
+
+      response =
+        conn
+        |> put_req_header("accept", "application/vnd.api+json")
+        |> get("/api/json/bouts", %{"include" => "feed,tags"})
+        |> json_response(200)
+
+      assert [%{"relationships" => relationships}] = response["data"]
+
+      assert [%{"type" => "tag", "id" => tag_id}] = relationships["tags"]["data"]
+      assert %{"type" => "feed", "id" => ^feed_id} = relationships["feed"]["data"]
+
+      assert %{"type" => "tag", "attributes" => %{"name" => "seagull", "slug" => "seagull"}} =
+               Enum.find(response["included"], &(&1["id"] == tag_id))
+    end
+  end
+end


### PR DESCRIPTION
Closes #1011.

`/api/json/bouts?include=tags` emitted `"type": null` for every tag — both in the relationship linkage and in `included`. JSON:API requires `type` on every resource identifier object and resource object, so a client can't tell what the relationship points at without hardcoding knowledge of the relationship name.

`Bout` declares `includes [:feed, :tags]`, but only `Feed` was set up as a JSON:API resource. `Tag` had neither the `AshJsonApi.Resource` extension nor a `json_api` type name, so AshJsonApi had nothing to emit and serialized `null`.

## Changes

- `Tag` and `ItemTag` get `AshJsonApi.Resource` and a `json_api do type "…" end` block. No routes — neither resource is addressable on its own; they only ever appear as includes. `ItemTag` had the same gap and would have hit it the moment `item_tags` was included.
- New `test/orcasite_web/json_api/bouts_test.exs` covering `GET /api/json/bouts?include=feed,tags`: asserts the tag linkage and the `included` tag both carry `"type": "tag"`. Verified it fails on `main` (`right: [%{"id" => "…", "type" => nil}]`) and passes with the fix.

Full suite: 30 tests, 0 failures, 1 skipped. `mix format --check-formatted` clean.

🤖 Opened by an agent working for @rainhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON:API support for tags and item tags.
  * Bouts now expose related tags and feeds through JSON:API responses, including tag attributes and resource types.

* **Tests**
  * Added coverage validating bout relationship data and included resource details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->