### PR TITLE
fix: authorize seeding at request time, not build time

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -23,6 +23,16 @@ end
 
 config :orcasite, :prod_host, System.get_env("PROD_HOST_URL", "live.orcasound.net")
 
+# Also set in config.exs, which Application.compile_env/3 reads to decide whether
+# the seed actions are compiled in at all. Repeating it here is redundant while
+# the server runs under Mix, since config.exs is re-evaluated at boot -- but it
+# would not be under a release, where config.exs is frozen into the artifact and
+# only runtime.exs runs at startup. Orcasite.Radio.Checks.SeedFromProdEnabled and
+# the validation in Orcasite.Radio.Seed authorize on this value, so it has to
+# describe the app serving the request under either model.
+config :orcasite,
+  enable_seed_from_prod: System.get_env("ENABLE_SEED_FROM_PROD", "false") == "true"
+
 if config_env() == :prod do
   database_url =
     System.get_env("DATABASE_URL") ||

--- a/server/lib/orcasite/radio/checks/seed_from_prod_enabled.ex
+++ b/server/lib/orcasite/radio/checks/seed_from_prod_enabled.ex
@@ -1,0 +1,20 @@
+defmodule Orcasite.Radio.Checks.SeedFromProdEnabled do
+  @moduledoc """
+  Passes only where seeding from prod is turned on for the running app.
+
+  Read at request time rather than compile time. Deploys build one artifact and
+  promote it across apps, so a compile-time answer describes the app the
+  artifact was built in rather than the app serving the request. `config.exs` is
+  evaluated at boot, so `Application.get_env/3` here reflects the serving app's
+  own `ENABLE_SEED_FROM_PROD`.
+  """
+  use Ash.Policy.SimpleCheck
+
+  @impl true
+  def describe(_opts), do: "seeding from prod is enabled for this environment"
+
+  @impl true
+  def match?(_actor, _context, _opts) do
+    Application.get_env(:orcasite, :enable_seed_from_prod, false) == true
+  end
+end

--- a/server/lib/orcasite/radio/checks/seed_from_prod_enabled.ex
+++ b/server/lib/orcasite/radio/checks/seed_from_prod_enabled.ex
@@ -4,9 +4,13 @@ defmodule Orcasite.Radio.Checks.SeedFromProdEnabled do
 
   Read at request time rather than compile time. Deploys build one artifact and
   promote it across apps, so a compile-time answer describes the app the
-  artifact was built in rather than the app serving the request. `config.exs` is
-  evaluated at boot, so `Application.get_env/3` here reflects the serving app's
-  own `ENABLE_SEED_FROM_PROD`.
+  artifact was built in rather than the app serving the request.
+
+  The value is set in `config/runtime.exs`, which runs at boot under both Mix
+  and a release. `config.exs` sets it too, for the `Application.compile_env/3`
+  calls that decide whether the seed actions exist at all -- but that copy is
+  frozen into the artifact under a release, so it must not be what authorizes a
+  request.
   """
   use Ash.Policy.SimpleCheck
 

--- a/server/lib/orcasite/radio/seed.ex
+++ b/server/lib/orcasite/radio/seed.ex
@@ -1,10 +1,26 @@
 defmodule Orcasite.Radio.Seed do
   use Ash.Resource,
     domain: Orcasite.Radio,
+    authorizers: [Ash.Policy.Authorizer],
     extensions: [AshGraphql.Resource, AshOban]
 
   resource do
     description "Non-persisted resource to seed records from specific time ranges from Orcasite prod"
+  end
+
+  # These mutations are exposed in the GraphQL schema unconditionally, and the
+  # changes behind them call Ash.bulk_create/4 with authorize?: false, so the
+  # target resources' own policies never run. This is the only place seeding can
+  # be gated, and without it the seed mutations are reachable by anyone.
+  #
+  # Checked at request time so the answer follows the app serving the request
+  # rather than the app the artifact was built in. The compile-time flags
+  # elsewhere decide whether the seed actions exist at all; this decides whether
+  # they may be invoked here and now.
+  policies do
+    policy always() do
+      authorize_if Orcasite.Radio.Checks.SeedFromProdEnabled
+    end
   end
 
   attributes do

--- a/server/test/orcasite/radio/seed_test.exs
+++ b/server/test/orcasite/radio/seed_test.exs
@@ -1,0 +1,79 @@
+defmodule Orcasite.Radio.SeedTest do
+  @moduledoc """
+  Tests for https://github.com/orcasound/orcasite/issues/1020.
+
+  The seed mutations are exposed in the GraphQL schema unconditionally. A
+  validation in `Orcasite.Radio.Seed` already rejects them when
+  `ENABLE_SEED_FROM_PROD` is off, but resource validations only run for
+  create/update/destroy actions -- not for generic actions. `seed_all` maps to
+  the generic `:time_range` action, so it reached its `run` block and did work
+  before failing partway through on a nested create.
+
+  A policy now covers every action type, so seeding is refused up front.
+  """
+
+  use Orcasite.DataCase, async: false
+
+  alias Orcasite.Radio.Seed
+
+  setup do
+    original = Application.get_env(:orcasite, :enable_seed_from_prod, false)
+    on_exit(fn -> Application.put_env(:orcasite, :enable_seed_from_prod, original) end)
+    :ok
+  end
+
+  defp set_seeding(enabled?), do: Application.put_env(:orcasite, :enable_seed_from_prod, enabled?)
+
+  describe "with seeding disabled" do
+    setup do
+      set_seeding(false)
+      :ok
+    end
+
+    test "the generic time_range action is forbidden outright" do
+      assert {:error, %Ash.Error.Forbidden{}} = run_time_range()
+    end
+
+    test "creating feeds is rejected" do
+      assert {:error, error} = Ash.create(Seed, %{}, action: :feeds)
+      assert error_message(error) =~ "Seeding is disabled"
+    end
+
+    test "seeding a resource is rejected" do
+      assert {:error, error} =
+               Ash.create(
+                 Seed,
+                 %{
+                   resource: :detection,
+                   feed_id: "whatever",
+                   start_time: DateTime.utc_now(),
+                   end_time: DateTime.utc_now()
+                 },
+                 action: :resource
+               )
+
+      assert error_message(error) =~ "Seeding is disabled"
+    end
+  end
+
+  describe "with seeding enabled" do
+    setup do
+      set_seeding(true)
+      :ok
+    end
+
+    test "authorization no longer refuses the generic time_range action" do
+      # Not asserting success -- that would reach the prod GraphQL API. Only
+      # that the policy is no longer what stops it.
+      refute match?({:error, %Ash.Error.Forbidden{}}, run_time_range())
+    end
+  end
+
+  defp run_time_range do
+    Seed
+    |> Ash.ActionInput.for_action(:time_range, %{})
+    |> Ash.run_action()
+  end
+
+  defp error_message(error), do: Exception.message(error)
+end

--- a/ui/src/pages/seed.tsx
+++ b/ui/src/pages/seed.tsx
@@ -310,9 +310,14 @@ function toLocalISOString(date: Date) {
 
 SeedPage.getLayout = getSimpleLayout;
 
-export async function getStaticProps() {
+// Per request, not at build time. getStaticProps ran during the build, so
+// whether this page existed was decided by the app the artifact was built in
+// rather than the app serving the request -- and one artifact is promoted
+// across dev, staging and production. Hiding the page is presentation only;
+// the seed actions are refused server-side by Orcasite.Radio.Seed's policy.
+export async function getServerSideProps() {
   const enableSeedFromProd = process.env.ENABLE_SEED_FROM_PROD === "true";
-  // Hide the seed page when `ENABLE_SEED_FROM_PROD` isn't enabled
+
   return !enableSeedFromProd ? { notFound: true } : { props: {} };
 }
 


### PR DESCRIPTION
Part of #1020. **This does not fully close the issue — see "What this does not fix".**

## What I found

The picture is different from how I described it in #1020, in both directions.

**Better than I said:** a validation in `Orcasite.Radio.Seed` already rejects seeding at *runtime* when `ENABLE_SEED_FROM_PROD` is off. I missed it when filing the issue. The mutations were never as unguarded as I claimed.

**Worse than I said:** resource validations only run for create/update/destroy actions, not generic actions. `seed_all` maps to `action :time_range`, a generic action, so the validation never applied to it. It ran: invoked the `feeds` create action, read every feed, and failed only partway through on a nested create — or, with no feeds present, returned `{:ok, []}` having refused nothing at all.

Verified by removing the policy and re-running the tests:

```
without policy:  Ash.run_action(:time_range) -> {:ok, []}
with policy:     Ash.run_action(:time_range) -> {:error, %Ash.Error.Forbidden{}}
```

## The change

A `policies` block on `Seed`, which covers every action type including generic ones. The check reads the flag via `Application.get_env/3`, so it follows the app serving the request — `config.exs` is evaluated at boot, since the server runs under Mix rather than as a release.

`Seed` is the only viable control point: `Seed.Changes.SeedResource` calls `Ash.bulk_create/4` with `authorize?: false`, so the target resources' policies never run.

`seed.tsx` moves from `getStaticProps` to `getServerSideProps`. Whether the page existed was decided at build time by the app the artifact was built in, and one artifact is promoted across all three. Hiding the page is presentation only; the policy is what refuses the work.

Tests cover both action types, disabled and enabled. Full server suite passes (34 tests, 0 failures, 1 skipped).

## Production is not exposed — correcting an earlier claim

I initially read `/seed` returning 200 on production as evidence that seeding was enabled there and the mutations were live. That was wrong, and the PR description said so before this edit.

What is actually true, each point tested rather than inferred:

- `ENABLE_SEED_FROM_PROD` is **unset on production**, so its runtime value is `false` and the existing validation rejects every seed create action.
- A `compile_env` mismatch really does refuse to boot (verified in the dev container: compile with the flag true, run with it false, and it errors). Production boots, so its compile-time value was also `false` — meaning the `create :seed` actions on `detection.ex`, `candidate.ex`, `audio_image.ex` and `bout.ex` were never compiled into the artifact.
- Building the UI with the flag unset makes `/seed` return 404 (verified locally), so the page serving on production does show the *Next* build environment had it set.

Those reconcile only if `mix compile` and `next build` saw different environments, which fits the buildpack setup: `server/elixir_buildpack.config` declares no `config_vars_to_export`, so the Elixir compile ran without the app's config vars while the phoenix-static buildpack's `next build` had them.

Net: the seed form is visible on live.orcasound.net but inert. Worth removing, not urgent.

## What this does not fix

`ENABLE_SEED_FROM_PROD` is still read through `Application.compile_env/3` in four resources and in `seed.ex`'s Oban block, so its value is fixed when the artifact is built and every app it is promoted to must agree with the build. Today that is `false` everywhere, which is why nothing breaks — but it means seeding cannot be enabled on one app without enabling it on all of them, and the build environment's value is not something the Heroku config vars for a given app can express.

Making the flag purely runtime means always compiling the seed actions in and deciding what to do about the Oban schedules, which would otherwise fire every minute on production and be denied every minute. That is a larger change and I have not attempted it here. Happy to take it as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime authorization for production data seeding.
  * Seeding is enabled only when explicitly configured.

* **Bug Fixes**
  * Updated the seed page to evaluate environment access on every request.
  * Prevented unauthorized seed actions when production seeding is disabled.

* **Tests**
  * Added coverage for blocked and permitted seed operations under different configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->