### PR TITLE
feat: add bin/smoke for post-promotion checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,27 @@ Because one artifact serves every environment, anything captured while it is bui
 
 Local development builds and runs in a single environment, where inlining is harmless, so [`ui/.env.development`](ui/.env.development) sets `NEXT_PUBLIC_*` normally.
 
+### Smoke checks
+
+Run [`bin/smoke`](bin/smoke) against an app after promoting to it:
+
+```shell
+bin/smoke https://live.orcasound.net
+```
+
+It exits non-zero if anything fails. The checks are self-configuring rather than
+hardcoded: they ask the app's own API what it should be showing and confirm the
+pages agree, so the same command works against any environment. An app serving
+another environment's data disagrees with its own API, which is the failure this
+deployment model invites and the reason these exist.
+
+Set `EXPECT_SEED_PAGE=1` for an environment where seeding is deliberately
+enabled; elsewhere `/seed` is expected to be absent.
+
+Nothing runs these automatically. The `health-check` job in
+[`heroku.yaml`](.github/workflows/heroku.yaml) fires on GitHub deployment
+events, which slug promotions no longer produce.
+
 ### Console
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -145,14 +145,21 @@ Run [`bin/smoke`](bin/smoke) against an app after promoting to it:
 bin/smoke https://live.orcasound.net
 ```
 
-It exits non-zero if anything fails. The checks are self-configuring rather than
-hardcoded: they ask the app's own API what it should be showing and confirm the
-pages agree, so the same command works against any environment. An app serving
-another environment's data disagrees with its own API, which is the failure this
-deployment model invites and the reason these exist.
+It exits non-zero if anything fails. Most checks are self-configuring: they ask
+the app's own API what it should be showing and confirm the pages agree, so the
+same command works against any environment. An app serving another environment's
+data disagrees with its own API, which is the failure this deployment model
+invites and the reason these exist. The feed comparison runs in both directions,
+because the failure that prompted this showed up as a page listing *extra*
+feeds — production serving a page built from development's list.
 
-Set `EXPECT_SEED_PAGE=1` for an environment where seeding is deliberately
-enabled; elsewhere `/seed` is expected to be absent.
+Two checks carry knowledge the app cannot supply, and both take an override:
+
+- `EXPECT_SEED_PAGE=1` where seeding is deliberately enabled; elsewhere `/seed`
+  is expected to be absent.
+- `ABSENT_SLUGS` lists feeds that exist only in development, so elsewhere they
+  must not resolve. A nonsense slug cannot cover this: a slug that never existed
+  anywhere was never prerendered either.
 
 Nothing runs these automatically. The `health-check` job in
 [`heroku.yaml`](.github/workflows/heroku.yaml) fires on GitHub deployment

--- a/bin/smoke
+++ b/bin/smoke
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Post-deploy checks for a running Orcasite app.
+#
+#     bin/smoke https://live.orcasound.net
+#
+# Deploys promote one prebuilt artifact across dev, staging and production, so
+# the failure worth catching is an app serving another environment's data or
+# configuration. These checks are deliberately self-configuring: rather than
+# comparing against hardcoded expectations, they ask the app's own API what it
+# should be showing and check that the pages agree. A page baked in a different
+# environment disagrees with the API of the one serving it.
+#
+# Exits non-zero if any check fails.
+
+set -uo pipefail
+
+BASE="${1:-}"
+
+if [ -z "$BASE" ]; then
+    echo "usage: bin/smoke <base-url>    e.g. bin/smoke https://live.orcasound.net" >&2
+    exit 64
+fi
+
+BASE="${BASE%/}"
+TIMEOUT=45
+failures=0
+
+pass() { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+fail() {
+    printf '  \033[31mFAIL\033[0m %s\n' "$1"
+    [ $# -gt 1 ] && printf '       %s\n' "$2"
+    failures=$((failures + 1))
+}
+
+get() { curl -sS --max-time "$TIMEOUT" "$BASE$1" 2>/dev/null; }
+status() { curl -sS -o /dev/null -w '%{http_code}' --max-time "$TIMEOUT" "$BASE$1" 2>/dev/null; }
+
+expect_status() {
+    local path="$1" want="$2" got
+    got="$(status "$path")"
+    if [ "$got" = "$want" ]; then
+        pass "$path -> $got"
+    else
+        fail "$path -> $got (expected $want)"
+    fi
+}
+
+echo "Smoke checking $BASE"
+
+# --- Reachability -----------------------------------------------------------
+echo
+echo "Routes"
+expect_status / 200
+expect_status /listen 200
+
+# --- Per-environment configuration -----------------------------------------
+# Injected per request, so it must describe the app answering the request. If
+# this reports another environment's bucket, the artifact is serving build-time
+# configuration and audio URLs point at the wrong place.
+echo
+echo "Runtime configuration"
+config="$(get /api/runtime-config)"
+
+if [ -z "$config" ]; then
+    fail "/api/runtime-config returned nothing"
+    bucket=""
+else
+    bucket="$(printf '%s' "$config" | grep -o '"s3Bucket":"[^"]*"' | cut -d'"' -f4)"
+
+    if [ -n "$bucket" ]; then
+        pass "s3Bucket = $bucket"
+    else
+        # An empty bucket is the deliberate last-resort fallback in
+        # ui/src/utils/runtimeConfig.ts, and means injection failed.
+        fail "no s3Bucket in /api/runtime-config" "$config"
+    fi
+fi
+
+# Loaded before the app bundle; without it the page falls back to defaults.
+if get /listen | grep -q '<script src="/api/runtime-config"'; then
+    pass "config script present in served HTML"
+else
+    fail "config script missing from /listen"
+fi
+
+# --- Pages must agree with this app's own API -------------------------------
+echo
+echo "Feeds match this environment's API"
+api_slugs="$(curl -sS --max-time "$TIMEOUT" -X POST "$BASE/graphql" \
+    -H 'Content-Type: application/json' \
+    -d '{"query":"query { feeds { slug } }"}' 2>/dev/null |
+    grep -o '"slug":"[^"]*"' | cut -d'"' -f4 | sort)"
+
+if [ -z "$api_slugs" ]; then
+    fail "no feeds returned from $BASE/graphql" "same-origin GraphQL may be unreachable"
+else
+    pass "API reports $(printf '%s\n' "$api_slugs" | wc -l | tr -d ' ') feeds"
+
+    listen_html="$(get /listen)"
+    missing=""
+    while IFS= read -r slug; do
+        [ -z "$slug" ] && continue
+        printf '%s' "$listen_html" | grep -q -- "$slug" || missing="$missing $slug"
+    done <<<"$api_slugs"
+
+    if [ -z "$missing" ]; then
+        pass "/listen lists every feed this API reports"
+    else
+        fail "/listen is missing feeds this API reports:$missing" \
+            "the page was probably rendered against a different environment"
+    fi
+
+    # A feed this API does not have must 404, not render. This is the original
+    # bug: pages prerendered from another environment's feed list were served
+    # everywhere, including hydrophones that only exist in development.
+    first_slug="$(printf '%s\n' "$api_slugs" | head -1)"
+    expect_status "/listen/$first_slug" 200
+
+    for absent in paul-test rpi-steve-test; do
+        if printf '%s\n' "$api_slugs" | grep -qx -- "$absent"; then
+            pass "/listen/$absent skipped (this environment really has it)"
+        else
+            expect_status "/listen/$absent" 404
+        fi
+    done
+fi
+
+expect_status /listen/definitely-not-a-real-feed 404
+
+# --- Nothing environment-specific baked into the bundle ---------------------
+# Endpoints resolve same-origin precisely so one artifact can serve every app.
+# An absolute host here means a build-time capture crept back in.
+echo
+echo "Client bundle"
+chunks="$(printf '%s' "${listen_html:-$(get /listen)}" |
+    grep -o '/_next/static/chunks/[^"]*\.js' | sort -u | head -12)"
+
+if [ -z "$chunks" ]; then
+    fail "found no client chunks to inspect"
+else
+    baked=""
+    while IFS= read -r chunk; do
+        [ -z "$chunk" ] && continue
+        found="$(get "$chunk" | grep -oh 'https\?://[a-z0-9.-]*/graphql\|wss\?://[a-z0-9.:-]*/socket' || true)"
+        [ -n "$found" ] && baked="$baked $found"
+    done <<<"$chunks"
+
+    if [ -z "$baked" ]; then
+        pass "no absolute API host baked into $(printf '%s\n' "$chunks" | wc -l | tr -d ' ') chunks"
+    else
+        fail "absolute API host in client bundle:$baked"
+    fi
+fi
+
+# --- Developer tooling should not be public ---------------------------------
+# Visibility follows ENABLE_SEED_FROM_PROD for the serving app. Pass
+# EXPECT_SEED_PAGE=1 for an environment where seeding is deliberately on.
+echo
+echo "Seed page"
+if [ "${EXPECT_SEED_PAGE:-0}" = "1" ]; then
+    expect_status /seed 200
+else
+    expect_status /seed 404
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "All checks passed."
+    exit 0
+fi
+
+echo "$failures check(s) failed."
+exit 1

--- a/bin/smoke
+++ b/bin/smoke
@@ -5,10 +5,10 @@
 #
 # Deploys promote one prebuilt artifact across dev, staging and production, so
 # the failure worth catching is an app serving another environment's data or
-# configuration. These checks are deliberately self-configuring: rather than
-# comparing against hardcoded expectations, they ask the app's own API what it
-# should be showing and check that the pages agree. A page baked in a different
-# environment disagrees with the API of the one serving it.
+# configuration. Most checks are self-configuring: they ask the app's own API
+# what it should be showing and confirm the pages agree, so the same command
+# works against any environment. Two checks carry operator knowledge instead,
+# each marked below, because the app's public surface cannot supply it.
 #
 # Exits non-zero if any check fails.
 
@@ -25,15 +25,30 @@ BASE="${BASE%/}"
 TIMEOUT=45
 failures=0
 
-pass() { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+# Retries matter: this is meant to run right after a promotion, while dynos are
+# still restarting and the router returns transient 503s.
+CURL_OPTS=(-sS -L --max-time "$TIMEOUT" --retry 3 --retry-connrefused)
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    C_OK=$'\033[32m'
+    C_BAD=$'\033[31m'
+    C_OFF=$'\033[0m'
+else
+    C_OK="" C_BAD="" C_OFF=""
+fi
+
+pass() { printf '  %sok%s   %s\n' "$C_OK" "$C_OFF" "$1"; }
+
 fail() {
-    printf '  \033[31mFAIL\033[0m %s\n' "$1"
-    [ $# -gt 1 ] && printf '       %s\n' "$2"
+    printf '  %sFAIL%s %s\n' "$C_BAD" "$C_OFF" "$1"
+    if [ $# -gt 1 ]; then
+        printf '       %s\n' "$2"
+    fi
     failures=$((failures + 1))
 }
 
-get() { curl -sS --max-time "$TIMEOUT" "$BASE$1" 2>/dev/null; }
-status() { curl -sS -o /dev/null -w '%{http_code}' --max-time "$TIMEOUT" "$BASE$1" 2>/dev/null; }
+get() { curl "${CURL_OPTS[@]}" "$BASE$1"; }
+status() { curl "${CURL_OPTS[@]}" -o /dev/null -w '%{http_code}' "$BASE$1"; }
 
 expect_status() {
     local path="$1" want="$2" got
@@ -52,6 +67,10 @@ echo
 echo "Routes"
 expect_status / 200
 expect_status /listen 200
+
+# Fetched once and reused: mid-restart, separate requests can land on different
+# dynos and disagree with each other.
+listen_html="$(get /listen)"
 
 # --- Per-environment configuration -----------------------------------------
 # Injected per request, so it must describe the app answering the request. If
@@ -76,8 +95,10 @@ else
     fi
 fi
 
-# Loaded before the app bundle; without it the page falls back to defaults.
-if get /listen | grep -q '<script src="/api/runtime-config"'; then
+# Matched against a variable rather than through a pipe: `curl | grep -q` lets
+# grep exit on first match and kills curl with EPIPE, which pipefail would
+# report as a failed check once the page outgrows the pipe buffer.
+if [[ "$listen_html" == *'<script src="/api/runtime-config"'* ]]; then
     pass "config script present in served HTML"
 else
     fail "config script missing from /listen"
@@ -86,75 +107,112 @@ fi
 # --- Pages must agree with this app's own API -------------------------------
 echo
 echo "Feeds match this environment's API"
-api_slugs="$(curl -sS --max-time "$TIMEOUT" -X POST "$BASE/graphql" \
+feeds_response="$(curl "${CURL_OPTS[@]}" -X POST "$BASE/graphql" \
     -H 'Content-Type: application/json' \
-    -d '{"query":"query { feeds { slug } }"}' 2>/dev/null |
-    grep -o '"slug":"[^"]*"' | cut -d'"' -f4 | sort)"
+    -d '{"query":"query { feeds { slug } }"}')"
 
-if [ -z "$api_slugs" ]; then
-    fail "no feeds returned from $BASE/graphql" "same-origin GraphQL may be unreachable"
+api_slugs="$(printf '%s' "$feeds_response" | grep -o '"slug":"[^"]*"' | cut -d'"' -f4 | sort -u)"
+
+if [ -z "$feeds_response" ]; then
+    fail "no response from $BASE/graphql" "same-origin GraphQL may be unreachable"
+elif [ -z "$api_slugs" ]; then
+    # An empty list is a real answer; distinguish it from an unreachable API so
+    # a freshly reset database does not look like an outage.
+    fail "API returned no feeds" "$(printf '%s' "$feeds_response" | head -c 200)"
 else
-    pass "API reports $(printf '%s\n' "$api_slugs" | wc -l | tr -d ' ') feeds"
+    api_count="$(printf '%s\n' "$api_slugs" | wc -l | tr -d ' ')"
+    pass "API reports $api_count feeds"
 
-    listen_html="$(get /listen)"
-    missing=""
-    while IFS= read -r slug; do
-        [ -z "$slug" ] && continue
-        printf '%s' "$listen_html" | grep -q -- "$slug" || missing="$missing $slug"
-    done <<<"$api_slugs"
+    # Compared both ways. A page missing feeds is the obvious failure, but the
+    # bug this script exists for showed up as the opposite: production served a
+    # page baked from development's feed list, which is a superset of its own.
+    # Checking only that the API's feeds appear would have passed on it.
+    page_slugs="$(printf '%s' "$listen_html" |
+        grep -o 'href="/listen/[^"]*"' |
+        sed 's|.*/listen/||; s|"$||' | sort -u)"
 
-    if [ -z "$missing" ]; then
-        pass "/listen lists every feed this API reports"
+    missing="$(comm -23 <(printf '%s\n' "$api_slugs") <(printf '%s\n' "$page_slugs") | tr '\n' ' ')"
+    extra="$(comm -13 <(printf '%s\n' "$api_slugs") <(printf '%s\n' "$page_slugs") | tr '\n' ' ')"
+
+    if [ -z "${missing// /}" ] && [ -z "${extra// /}" ]; then
+        pass "/listen lists exactly the feeds this API reports"
     else
-        fail "/listen is missing feeds this API reports:$missing" \
-            "the page was probably rendered against a different environment"
+        [ -n "${missing// /}" ] && fail "/listen is missing feeds the API reports: $missing" \
+            "the page may have been rendered against a different environment"
+        [ -n "${extra// /}" ] && fail "/listen lists feeds the API does not have: $extra" \
+            "the page was rendered against a different environment"
     fi
 
-    # A feed this API does not have must 404, not render. This is the original
-    # bug: pages prerendered from another environment's feed list were served
-    # everywhere, including hydrophones that only exist in development.
     first_slug="$(printf '%s\n' "$api_slugs" | head -1)"
     expect_status "/listen/$first_slug" 200
-
-    for absent in paul-test rpi-steve-test; do
-        if printf '%s\n' "$api_slugs" | grep -qx -- "$absent"; then
-            pass "/listen/$absent skipped (this environment really has it)"
-        else
-            expect_status "/listen/$absent" 404
-        fi
-    done
 fi
 
 expect_status /listen/definitely-not-a-real-feed 404
 
+# OPERATOR KNOWLEDGE, not derived from the app. A nonsense slug only proves
+# unknown feeds 404; it cannot catch detail pages prerendered from another
+# environment's feed list, because a slug that never existed anywhere was never
+# prerendered either. These are real feeds that exist only in development, so
+# outside development they must not resolve. Override for an environment that
+# legitimately has them.
+ABSENT_SLUGS="${ABSENT_SLUGS:-paul-test rpi-steve-test}"
+
+for absent in $ABSENT_SLUGS; do
+    if printf '%s\n' "$api_slugs" | grep -qxF -- "$absent"; then
+        pass "/listen/$absent skipped (this environment really has it)"
+    else
+        expect_status "/listen/$absent" 404
+    fi
+done
+
 # --- Nothing environment-specific baked into the bundle ---------------------
-# Endpoints resolve same-origin precisely so one artifact can serve every app.
-# An absolute host here means a build-time capture crept back in.
+# Endpoints resolve same-origin, and the bucket is injected at request time,
+# precisely so one artifact can serve every app. Anything absolute here means a
+# build-time capture crept back in.
 echo
 echo "Client bundle"
-chunks="$(printf '%s' "${listen_html:-$(get /listen)}" |
-    grep -o '/_next/static/chunks/[^"]*\.js' | sort -u | head -12)"
+chunks="$(printf '%s' "$listen_html" | grep -o '/_next/static/chunks/[^"]*\.js' | sort -u)"
 
 if [ -z "$chunks" ]; then
     fail "found no client chunks to inspect"
 else
-    baked=""
+    # Every chunk, deliberately. Sorted order puts the app chunks (_app, main,
+    # webpack, the page chunk) last, so truncating this list drops exactly the
+    # files where inlined values land.
+    baked="" unreadable="" scanned=0
     while IFS= read -r chunk; do
         [ -z "$chunk" ] && continue
-        found="$(get "$chunk" | grep -oh 'https\?://[a-z0-9.-]*/graphql\|wss\?://[a-z0-9.:-]*/socket' || true)"
-        [ -n "$found" ] && baked="$baked $found"
+        body="$(get "$chunk")"
+
+        if [ -z "$body" ]; then
+            unreadable="$unreadable $chunk"
+            continue
+        fi
+
+        scanned=$((scanned + 1))
+        found="$(printf '%s' "$body" |
+            grep -oh 'https\?://[a-z0-9.-]*/graphql\|wss\?://[a-z0-9.:-]*/socket\|[a-z-]*-orcasound-net' |
+            sort -u | tr '\n' ' ')"
+        [ -n "$found" ] && baked="$baked $chunk:$found"
     done <<<"$chunks"
 
+    if [ -n "$unreadable" ]; then
+        # Silently treating these as clean would report a pass having inspected
+        # nothing.
+        fail "could not fetch client chunks:$unreadable"
+    fi
+
     if [ -z "$baked" ]; then
-        pass "no absolute API host baked into $(printf '%s\n' "$chunks" | wc -l | tr -d ' ') chunks"
+        pass "no absolute API host or bucket in $scanned chunks"
     else
-        fail "absolute API host in client bundle:$baked"
+        fail "environment-specific value baked into client bundle:$baked"
     fi
 fi
 
 # --- Developer tooling should not be public ---------------------------------
-# Visibility follows ENABLE_SEED_FROM_PROD for the serving app. Pass
-# EXPECT_SEED_PAGE=1 for an environment where seeding is deliberately on.
+# OPERATOR KNOWLEDGE. Visibility follows ENABLE_SEED_FROM_PROD for the serving
+# app, which cannot be read from the app's public surface without trusting the
+# thing under test. Set EXPECT_SEED_PAGE=1 where seeding is deliberately on.
 echo
 echo "Seed page"
 if [ "${EXPECT_SEED_PAGE:-0}" = "1" ]; then


### PR DESCRIPTION
Deploys promote one prebuilt artifact across dev, staging and production, so the failure worth catching is an app serving another environment's data or configuration — the bug fixed in #1019, which reached production and needed a rollback.

Nothing checks for it today. CI only runs the Elixir suite against containers. The `health-check` job in `heroku.yaml` fires on GitHub deployment events, and promotions stopped producing those:

```
orcasite       last deployment record: 2025-11-15  (472133c)
orcasite-beta  last deployment record: 2025-11-15  (472133c)
```

Review apps still create them, so the workflow works — it just never fires for the environments that matter. And even when it did, it fetched `/` and accepted any success status, which would have passed happily while production listed development's hydrophones.

## Approach

The checks are **self-configuring rather than hardcoded**, so one command works against any environment with no per-app expectations to maintain:

```shell
bin/smoke https://live.orcasound.net
```

It asks the app's own API which feeds it has, then confirms `/listen` lists exactly those, that one of them renders, and that feeds the API does not have return 404. A page rendered against a different environment disagrees with the API of the one serving it — which is precisely the bug, expressed as an invariant instead of a fixture.

It also checks that the injected runtime config reports a bucket, that the config script reaches the served HTML, that no absolute API host is baked into the client bundle, and that `/seed` is absent unless `EXPECT_SEED_PAGE=1`.

Pure bash and curl, no dependencies, shellcheck clean, exits non-zero on failure.

## Verified against all three environments

Dev passes fully. Beta and production pass everything except the seed page:

```
Seed page
  FAIL /seed -> 200 (expected 404)
```

That is correct, not a bug in the script: #1022 is merged but not yet promoted, so beta and production still serve a build that baked the page's visibility in. It should go green once you promote — which makes it a decent first exercise of the thing.

## Not automated

Deliberately a script rather than a workflow, since promotions emit no events a workflow could hang off. Run it by hand after promoting. If you would rather have it wired into CI against a fixed URL, or run on a schedule, happy to add that.

🤖