### PR TITLE
fix: stop the seed test from actually seeding from production

### DIFF
--- a/server/test/orcasite/radio/seed_test.exs
+++ b/server/test/orcasite/radio/seed_test.exs
@@ -10,6 +10,10 @@ defmodule Orcasite.Radio.SeedTest do
   before failing partway through on a nested create.
 
   A policy now covers every action type, so seeding is refused up front.
+
+  Nothing here invokes a seed action that would be permitted to run. Seeding
+  reaches the production API over the network and writes records; these tests
+  are about whether it is allowed, not about doing it.
   """
 
   use Orcasite.DataCase, async: false
@@ -30,8 +34,8 @@ defmodule Orcasite.Radio.SeedTest do
       :ok
     end
 
-    test "the generic time_range action is forbidden outright" do
-      assert {:error, %Ash.Error.Forbidden{}} = run_time_range()
+    test "the generic time_range action is not authorized" do
+      refute Ash.can?({Seed, :time_range}, nil)
     end
 
     test "creating feeds is rejected" do
@@ -62,18 +66,17 @@ defmodule Orcasite.Radio.SeedTest do
       :ok
     end
 
-    test "authorization no longer refuses the generic time_range action" do
-      # Not asserting success -- that would reach the prod GraphQL API. Only
-      # that the policy is no longer what stops it.
-      refute match?({:error, %Ash.Error.Forbidden{}}, run_time_range())
+    test "the generic time_range action is authorized" do
+      assert Ash.can?({Seed, :time_range}, nil)
     end
   end
 
-  defp run_time_range do
-    Seed
-    |> Ash.ActionInput.for_action(:time_range, %{})
-    |> Ash.run_action()
-  end
+  # Ash.can?/2 rather than running the action. Running :time_range executes it:
+  # it seeds feeds from the production API over the network, reads them back,
+  # and seeds a resource per feed. An earlier version of this test did that in
+  # CI, which reached live.orcasound.net and then crashed in a spawned task
+  # outside the sandboxed connection. Authorization is what these tests are
+  # about, so check it directly and leave the side effects alone.
 
   defp error_message(error), do: Exception.message(error)
 end


### PR DESCRIPTION
Fixes the red build on `main` ([run 31962449013](https://github.com/orcasound/orcasite/actions/runs/31962449013/job/95202385243)). My test, from #1022.

## What it was doing

`Ash.run_action/1` **runs** the action, and `:time_range` seeds. Its `run` block calls the `feeds` create action — which fetches from the production GraphQL API over the network — then reads the created feeds back and seeds a resource for each one. So in CI the test reached live.orcasound.net, created feed records, and then crashed generating spectrograms in a task spawned outside the sandboxed connection:

```
** (ArgumentError) The first argument of `Ash.Changeset.for_update/2-4` must be one of:
   - a record
   Got: nil
     detection/changes/generate_spectrograms.ex:30
```

It passed locally only because my test database had no feeds, so the loop had nothing to iterate. The comment I put on it — "Not asserting success, that would reach the prod GraphQL API" — was wrong: it avoided *asserting* success, not *performing* the work.

## The fix

`Ash.can?/2` answers what these tests actually ask — whether the policy permits the action — without executing it. The create-action tests are unaffected, since the validation rejects them before their change ever runs.

The suite drops from **17.3s to 0.5s**, which is the network calls going away.

Verified against the bumped deps from #1021 (ash 3.5.43): 34 tests, 0 failures, 1 skipped.

## Worth noting

A test that seeds from production on every CI run is bad regardless of whether it passes. It was making real requests to the live site from GitHub runners. Nothing was written to production — the seeding pulls *from* prod and writes locally — but the traffic was real and unnecessary.

🤖