### PR TITLE
fix(ui): paginate the bouts list, newest first

### DIFF
--- a/ui/src/pages/bouts/index.tsx
+++ b/ui/src/pages/bouts/index.tsx
@@ -5,7 +5,9 @@ import {
   ListItem,
   MenuItem,
   Select,
+  TablePagination,
 } from "@mui/material";
+import { keepPreviousData } from "@tanstack/react-query";
 import Head from "next/head";
 import { useCallback, useMemo, useState } from "react";
 
@@ -17,6 +19,8 @@ import type { NextPageWithLayout } from "@/pages/_app";
 
 const BoutsPage: NextPageWithLayout = () => {
   const [sortField, setSortField] = useState("name");
+  const [pastBoutsPage, setPastBoutsPage] = useState(0);
+  const [pastBoutsPerPage, setPastBoutsPerPage] = useState(50);
   const [sortStats, setSortStats] = useState<
     Record<string, Record<string, number>>
   >({});
@@ -27,13 +31,37 @@ const BoutsPage: NextPageWithLayout = () => {
   const currentBouts =
     useBoutsQuery({
       filter: { endTime: { isNil: true } },
-      sort: { field: "START_TIME" },
+      sort: { field: "START_TIME", order: "DESC" },
     }).data?.bouts?.results ?? [];
-  const pastBouts =
-    useBoutsQuery({
+
+  const pastBoutsQuery = useBoutsQuery(
+    {
       filter: { endTime: { isNil: false } },
-      sort: { field: "START_TIME" },
-    }).data?.bouts?.results ?? [];
+      sort: { field: "START_TIME", order: "DESC" },
+      limit: pastBoutsPerPage,
+      offset: pastBoutsPage * pastBoutsPerPage,
+    },
+    // each page is its own query key, so without this the list empties while
+    // the next page loads and everything below it jumps
+    { placeholderData: keepPreviousData },
+  );
+  const pastBouts = pastBoutsQuery.data?.bouts?.results ?? [];
+  const pastBoutsCount = pastBoutsQuery.data?.bouts?.count ?? 0;
+
+  const pastBoutsPagination = {
+    count: pastBoutsCount,
+    page: pastBoutsPage,
+    rowsPerPage: pastBoutsPerPage,
+    onPageChange: (_e: unknown, newPage: number) => setPastBoutsPage(newPage),
+    onRowsPerPageChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+      setPastBoutsPerPage(Number(e.target.value));
+      setPastBoutsPage(0);
+    },
+    // Bout's :index action sets no max_page_size, so Ash's default of 250 is the
+    // ceiling; a larger option would be clamped server side while the offset
+    // kept advancing, hiding rows
+    rowsPerPageOptions: [10, 50, 100, 250],
+  };
 
   const handleStatUpdate = useCallback(
     (feedId: string, stat: string, value: number) => {
@@ -121,6 +149,16 @@ const BoutsPage: NextPageWithLayout = () => {
         >
           <h2>Bouts</h2>
           <Box>
+            {pastBoutsQuery.isSuccess && (
+              <TablePagination
+                {...pastBoutsPagination}
+                component="div"
+                sx={{
+                  borderBottom: 1,
+                  borderColor: "divider",
+                }}
+              />
+            )}
             <List>
               {pastBouts.map((bout) => (
                 <ListItem key={bout.id}>
@@ -128,6 +166,9 @@ const BoutsPage: NextPageWithLayout = () => {
                 </ListItem>
               ))}
             </List>
+            {pastBoutsQuery.isSuccess && (
+              <TablePagination {...pastBoutsPagination} component="div" />
+            )}
           </Box>
         </Box>
       </main>

--- a/ui/test/fixtures/bouts.ts
+++ b/ui/test/fixtures/bouts.ts
@@ -1,0 +1,37 @@
+import type { BoutPartsFragment, FeedPartsFragment } from "@/graphql/generated";
+
+import { buildFeed } from "./feeds";
+import { uniqueId } from "./sequence";
+
+export type BoutFixture = BoutPartsFragment & { feed: FeedPartsFragment };
+
+const FIVE_MINUTES = 5 * 60_000;
+const HOUR = 60 * 60_000;
+
+// Defaults are valid and boring; a test overrides only the fields its assertion is about
+export function buildBout(overrides: Partial<BoutFixture> = {}): BoutFixture {
+  const startTime = overrides.startTime ?? new Date("2026-01-01T12:00:00Z");
+
+  return {
+    id: uniqueId("bout"),
+    name: "Bout",
+    category: "BIOPHONY",
+    startTime,
+    endTime: new Date(startTime.getTime() + FIVE_MINUTES),
+    duration: FIVE_MINUTES / 1000,
+    feed: buildFeed(),
+    ...overrides,
+  };
+}
+
+/** `count` ended bouts an hour apart, newest first: "Bout 1" is the most recent. */
+export function buildEndedBouts(count: number): BoutFixture[] {
+  const newest = new Date("2026-01-01T12:00:00Z").getTime();
+
+  return Array.from({ length: count }, (_, index) =>
+    buildBout({
+      name: `Bout ${index + 1}`,
+      startTime: new Date(newest - index * HOUR),
+    }),
+  );
+}

--- a/ui/test/fixtures/feeds.ts
+++ b/ui/test/fixtures/feeds.ts
@@ -1,0 +1,22 @@
+import type { FeedPartsFragment } from "@/graphql/generated";
+
+import { uniqueId } from "./sequence";
+
+// Defaults are valid and boring; a test overrides only the fields its assertion is about
+export function buildFeed(
+  overrides: Partial<FeedPartsFragment> = {},
+): FeedPartsFragment {
+  return {
+    id: uniqueId("feed"),
+    name: "Orcasound Lab",
+    slug: "orcasound-lab",
+    nodeName: "rpi_orcasound_lab",
+    latLng: { lat: 48.5583, lng: -123.1735 },
+    introHtml: "",
+    thumbUrl: "",
+    imageUrl: "",
+    mapUrl: "",
+    bucket: "audio-orcasound-net",
+    ...overrides,
+  };
+}

--- a/ui/test/fixtures/sequence.ts
+++ b/ui/test/fixtures/sequence.ts
@@ -1,0 +1,4 @@
+let next = 1;
+
+/** An id no other fixture in the run has, like the API's prefixed ids. */
+export const uniqueId = (prefix: string) => `${prefix}_${next++}`;

--- a/ui/test/graphql.ts
+++ b/ui/test/graphql.ts
@@ -1,0 +1,53 @@
+// A stand-in for the GraphQL API, for tests that render components which query it.
+//
+// It stubs fetch, the seam every generated hook goes through (src/graphql/client.ts),
+// so a test runs the real hooks and cache and only the network is fake.
+
+// Bout's :index action, like most read actions here, sets no max_page_size, so Ash
+// applies its default and AshGraphql quietly returns min(limit, 250) rows
+export const ASH_DEFAULT_MAX_PAGE_SIZE = 250;
+
+// Variables arrive as parsed JSON, so each resolver declares the type it expects.
+// `never` lets resolvers with different variable types share one map.
+type Resolver = (variables: never) => unknown;
+
+/**
+ * Routes each request to the resolver named after its operation: `query bouts(...)`
+ * goes to `resolvers.bouts`, and whatever it returns becomes the response's `data`.
+ * An operation without a resolver throws, so a missing stub fails instead of hanging.
+ * The real fetch comes back after each test (`unstubGlobals` in the vitest config).
+ */
+export function stubGraphql(resolvers: Record<string, Resolver>) {
+  const fetch = vi.fn(async (_url: string, init?: RequestInit) => {
+    const { query, variables } = JSON.parse(String(init?.body));
+    const operation = /^\s*(?:query|mutation)\s+(\w+)/.exec(query)?.[1] ?? "";
+    const resolve = resolvers[operation];
+
+    if (!resolve) {
+      throw new Error(`No stub for GraphQL operation "${operation}"`);
+    }
+
+    return Response.json({ data: await resolve((variables ?? {}) as never) });
+  });
+
+  vi.stubGlobal("fetch", fetch);
+  return fetch;
+}
+
+/**
+ * One page of `rows` the way AshGraphql answers an offset-paginated read: the limit
+ * capped at the action's max page size, with the total count alongside.
+ */
+export function offsetPage<Row>(
+  rows: Row[],
+  { limit, offset }: { limit: number; offset: number },
+  maxPageSize = ASH_DEFAULT_MAX_PAGE_SIZE,
+) {
+  const pageSize = Math.min(limit, maxPageSize);
+
+  return {
+    count: rows.length,
+    hasNextPage: offset + pageSize < rows.length,
+    results: rows.slice(offset, offset + pageSize),
+  };
+}

--- a/ui/test/pages/bouts.test.tsx
+++ b/ui/test/pages/bouts.test.tsx
@@ -1,0 +1,108 @@
+import { type BoutFixture, buildEndedBouts } from "@test/fixtures/bouts";
+import {
+  ASH_DEFAULT_MAX_PAGE_SIZE,
+  offsetPage,
+  stubGraphql,
+} from "@test/graphql";
+import { renderWithProviders, screen, waitFor, within } from "@test/utils";
+import type { UserEvent } from "@testing-library/user-event";
+
+import type { BoutsQueryVariables } from "@/graphql/generated";
+import BoutsPage from "@/pages/bouts";
+
+// Lives outside src/pages because Next turns every file in there into a route.
+
+const DEFAULT_PAGE_SIZE = 50;
+// $limit's default in the bouts query document, used when the page sends none
+const QUERY_DEFAULT_LIMIT = 100;
+
+const isNewestFirst = (sort: BoutsQueryVariables["sort"]) =>
+  [sort].flat().some((s) => s?.field === "START_TIME" && s.order === "DESC");
+
+/**
+ * The API as this page sees it: no bout in progress, no feeds, and `ended` served one
+ * page at a time. A page at `holdOffset` never arrives.
+ */
+function serveBouts(ended: BoutFixture[], { holdOffset = -1 } = {}) {
+  stubGraphql({
+    feeds: () => ({ feeds: [] }),
+    detectionsCount: () => ({ feedDetectionsCount: 0 }),
+    bouts: (variables: BoutsQueryVariables) => {
+      const inProgress = variables.filter?.endTime?.isNil;
+      const rows = inProgress
+        ? []
+        : isNewestFirst(variables.sort)
+          ? ended
+          : [...ended].reverse();
+      const offset = variables.offset ?? 0;
+      const limit = variables.limit ?? QUERY_DEFAULT_LIMIT;
+
+      if (!inProgress && offset === holdOffset) return new Promise(() => {});
+
+      return { bouts: offsetPage(rows, { limit, offset }) };
+    },
+  });
+}
+
+// the list has a pagination control above it and one below; both drive the same page
+const nextPageButton = () =>
+  screen.getAllByRole("button", { name: /go to next page/i })[0];
+
+const visibleBoutNames = () =>
+  screen
+    .queryAllByRole("heading", { level: 5, name: /^Bout \d+$/ })
+    .map((heading) => heading.textContent);
+
+async function chooseLargestPageSize(user: UserEvent) {
+  await user.click(
+    screen.getAllByRole("combobox", { name: /rows per page/i })[0],
+  );
+  const sizes = within(screen.getByRole("listbox")).getAllByRole("option");
+  const largest = sizes.reduce((a, b) =>
+    Number(b.textContent) > Number(a.textContent) ? b : a,
+  );
+  await user.click(largest);
+  await screen.findByRole("heading", {
+    name: `Bout ${DEFAULT_PAGE_SIZE + 1}`,
+  });
+}
+
+async function collectBoutsAcrossPages(user: UserEvent) {
+  const seen = visibleBoutNames();
+
+  while (!nextPageButton().hasAttribute("disabled")) {
+    const firstOnPage = visibleBoutNames()[0];
+    await user.click(nextPageButton());
+    await waitFor(() => expect(visibleBoutNames()[0]).not.toBe(firstOnPage));
+    seen.push(...visibleBoutNames());
+  }
+
+  return seen;
+}
+
+describe("BoutsPage", () => {
+  it("keeps the current page on screen while the next one loads", async () => {
+    serveBouts(buildEndedBouts(120), { holdOffset: DEFAULT_PAGE_SIZE });
+    const { user } = renderWithProviders(<BoutsPage />);
+    await screen.findByRole("heading", { name: "Bout 1" });
+
+    await user.click(nextPageButton());
+
+    expect(screen.getAllByText("51–100 of 120")[0]).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Bout 1" })).toBeInTheDocument();
+    expect(visibleBoutNames()).toHaveLength(DEFAULT_PAGE_SIZE);
+  });
+
+  it("reaches every ended bout, newest first, at the largest page size", async () => {
+    // more bouts than the server returns in one page, so an oversized page skips some
+    const bouts = buildEndedBouts(ASH_DEFAULT_MAX_PAGE_SIZE + 50);
+    serveBouts(bouts);
+    const { user } = renderWithProviders(<BoutsPage />);
+    await screen.findByRole("heading", { name: "Bout 1" });
+    await chooseLargestPageSize(user);
+
+    const seen = await collectBoutsAcrossPages(user);
+
+    expect(seen).toEqual(bouts.map((bout) => bout.name));
+  }, 30_000);
+});

--- a/ui/vitest.config.mts
+++ b/ui/vitest.config.mts
@@ -2,8 +2,22 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  // Reads `paths` straight from tsconfig.json so they don't drift
-  plugins: [tsconfigPaths()],
+  plugins: [
+    // Reads `paths` straight from tsconfig.json so they don't drift
+    tsconfigPaths(),
+
+    // Next turns an image import into { src, height, width } and Vite into a URL
+    // string; this gives tests Next's shape, so components reading `.src` work
+    {
+      name: "next-static-image",
+      enforce: "pre",
+      load(id) {
+        if (/\.(svg|png|jpe?g|gif|webp|avif)$/.test(id)) {
+          return `export default ${JSON.stringify({ src: id, height: 1, width: 1 })}`;
+        }
+      },
+    },
+  ],
 
   // tsconfig.json sets `jsx: "preserve"` for Next's compiler, which would otherwise
   // leave raw JSX behind
@@ -21,5 +35,8 @@ export default defineConfig({
 
     clearMocks: true,
     restoreMocks: true,
+
+    // test/graphql.ts stubs fetch; put the real one back after each test
+    unstubGlobals: true,
   },
 });


### PR DESCRIPTION
Closes #990

The Bouts list on `/bouts` asked for ended bouts with no limit or offset, so it got the API's default of 100, oldest first, and couldn't reach the rest. With 214 ended bouts seeded from production, the newest 114 never showed up.

The list now pages with `limit` and `offset` through MUI `TablePagination`, 50 rows by default, with the control above and below the list like the reports page. Both lists sort newest first. Rows per page stop at 250, the most the bouts action returns in one page, and `keepPreviousData` keeps the current page on screen while the next one loads.

`ui/test/pages/bouts.test.tsx` covers the two cases a browser test handles badly: clicking next while that page is still loading, and reaching every bout when there are more than 250. The API is stubbed at `fetch`, and `vitest.config.mts` gives image imports the shape Next gives them so `CategoryIcon` renders without warnings. Run them with `npm test` in `ui/`, CI doesn't run the UI suite yet.

Not changed here: the page number isn't in the URL, and a failed query or a count that shrinks under the current page shows an empty list, same as the reports page.

Checked by hand against a production-seeded database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination for past bouts with selectable page sizes of 10, 50, or 100.
  * Added loading feedback while changing pages and retained visibility of the current results.
  * Added retry support when past-bout loading fails.
  * Sorted current and past bouts with the newest first.

* **Tests**
  * Added coverage for pagination, ordering, loading states, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->